### PR TITLE
Fix module alias for build

### DIFF
--- a/src/modules/assets/components/assets/AssetsSearchForm.tsx
+++ b/src/modules/assets/components/assets/AssetsSearchForm.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent } from '@/components/ui/card';
-import { useAssetSolutions } from '@/hooks/useAssetSolutions';
+import { useAssetSolutions } from '@modules/assets/hooks/useAssetSolutions';
 
 interface AssetsSearchFormProps {
   searchTerm: string;

--- a/src/modules/assets/components/assets/EditAssetDialog.tsx
+++ b/src/modules/assets/components/assets/EditAssetDialog.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { AssetWithRelations } from '@modules/assets/hooks/useAssetsData';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { useAssetEditForm } from '@/hooks/useAssetEditForm';
+import { useAssetEditForm } from '@modules/assets/hooks/useAssetEditForm';
 import { referenceDataService } from '@modules/assets/services/referenceDataService';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import CommonFormFields from './edit/CommonFormFields';

--- a/src/modules/assets/pages/AddAsset.tsx
+++ b/src/modules/assets/pages/AddAsset.tsx
@@ -7,8 +7,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { PackagePlus, Smartphone, Wifi, ArrowLeft } from "lucide-react";
 import { useNavigate } from 'react-router-dom';
-import ChipForm from '@modules/assets/components/ChipForm';
-import EquipmentForm from '@modules/assets/components/EquipmentForm';
+import ChipForm from '@modules/assets/components/assets/ChipForm';
+import EquipmentForm from '@modules/assets/components/assets/EquipmentForm';
 
 const AddAsset = () => {
   const [selectedType, setSelectedType] = useState<'chip' | 'equipment' | null>(null);

--- a/src/modules/assets/pages/AssetsDashboard.tsx
+++ b/src/modules/assets/pages/AssetsDashboard.tsx
@@ -4,8 +4,8 @@ import { Badge } from "@/components/ui/badge";
 import { useAssets } from "@/context/useAssets";
 import { Asset } from '@/types/asset';
 import { AlertCircle, Clock, Users, Wifi } from 'lucide-react';
-import ProblemAssetsCard from '@modules/dashboard/components/ProblemAssetsCard';
-import AssetsStatusCard from '@modules/dashboard/components/AssetsStatusCard';
+import ProblemAssetsCard from '@modules/dashboard/components/dashboard/ProblemAssetsCard';
+import AssetsStatusCard from '@modules/dashboard/components/dashboard/AssetsStatusCard';
 
 const AssetsDashboard = () => {
   const { assets, loading } = useAssets();

--- a/src/modules/assets/pages/AssetsInventory.tsx
+++ b/src/modules/assets/pages/AssetsInventory.tsx
@@ -3,12 +3,12 @@ import React, { useState, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useAssetsData } from '@modules/assets/hooks/useAssetsData';
-import AssetsHeader from '@modules/assets/components/AssetsHeader';
-import AssetsSearchForm from '@modules/assets/components/AssetsSearchForm';
-import AssetsTable from '@modules/assets/components/AssetsTable';
-import AssetsPagination from '@modules/assets/components/AssetsPagination';
-import AssetsLoading from '@modules/assets/components/AssetsLoading';
-import AssetsError from '@modules/assets/components/AssetsError';
+import AssetsHeader from '@modules/assets/components/assets/AssetsHeader';
+import AssetsSearchForm from '@modules/assets/components/assets/AssetsSearchForm';
+import AssetsTable from '@modules/assets/components/assets/AssetsTable';
+import AssetsPagination from '@modules/assets/components/assets/AssetsPagination';
+import AssetsLoading from '@modules/assets/components/assets/AssetsLoading';
+import AssetsError from '@modules/assets/components/assets/AssetsError';
 
 const ASSETS_PER_PAGE = 10;
 

--- a/src/modules/assets/pages/RegisterAsset.tsx
+++ b/src/modules/assets/pages/RegisterAsset.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { StandardPageHeader } from "@/components/ui/standard-page-header";
 import { useNavigate } from "react-router-dom";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { RegisterAssetForm } from "@/pages/assets/register";
+import { RegisterAssetForm } from "@modules/assets/pages/assets/register";
 
 export default function RegisterAsset() {
   const navigate = useNavigate();

--- a/src/modules/associations/pages/AssetAssociation.tsx
+++ b/src/modules/associations/pages/AssetAssociation.tsx
@@ -10,7 +10,7 @@ import { ClientSelectionSimplified } from '@modules/associations/components/asso
 import { AssetSelection } from '@modules/associations/components/association/AssetSelection';
 import { AssociationSummary } from '@modules/associations/components/association/AssociationSummary';
 import { Client } from '@/types/client';
-import { useAssetAssociationState } from '@/hooks/useAssetAssociationState';
+import { useAssetAssociationState } from '@modules/assets/hooks/useAssetAssociationState';
 
 export interface SelectedAsset {
   id: string;

--- a/src/modules/bits/components/components/ReferralForm.tsx
+++ b/src/modules/bits/components/components/ReferralForm.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { useReferrals } from '../hooks/useBits';
+import { useReferrals } from '../../hooks/useBits';
 
 interface ReferralFormData {
   referred_name: string;

--- a/src/modules/bits/components/components/ReferralLink.tsx
+++ b/src/modules/bits/components/components/ReferralLink.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Copy, RefreshCw } from 'lucide-react';
-import { useBitsProfile } from '../hooks/useBits';
+import { useBitsProfile } from '../../hooks/useBits';
 import { toast } from '@/utils/toast';
 
 interface ReferralLinkProps {

--- a/src/modules/bits/components/components/RewardsList.tsx
+++ b/src/modules/bits/components/components/RewardsList.tsx
@@ -19,7 +19,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Gift, AlertCircle } from 'lucide-react';
 import { Reward } from '../types';
-import { useRewards, usePoints } from '../hooks/useBits';
+import { useRewards, usePoints } from '../../hooks/useBits';
 
 interface RewardsListProps {
   className?: string;

--- a/src/modules/bits/pages/BitsDashboard.tsx
+++ b/src/modules/bits/pages/BitsDashboard.tsx
@@ -2,11 +2,11 @@
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { PointsDisplay } from '@modules/bits/components/PointsDisplay';
-import { LevelProgress } from '@modules/bits/components/LevelProgress';
-import { ReferralLink } from '@modules/bits/components/ReferralLink';
-import { ReferralsList } from '@modules/bits/components/ReferralsList';
-import { UserBadgesList } from '@modules/bits/components/UserBadgesList';
+import { PointsDisplay } from '@modules/bits/components/components/PointsDisplay';
+import { LevelProgress } from '@modules/bits/components/components/LevelProgress';
+import { ReferralLink } from '@modules/bits/components/components/ReferralLink';
+import { ReferralsList } from '@modules/bits/components/components/ReferralsList';
+import { UserBadgesList } from '@modules/bits/components/components/UserBadgesList';
 import { usePoints, useReferrals, useBadges, useLevels } from '@modules/bits/hooks/useBits';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';

--- a/src/modules/bits/pages/BitsIndicateNow.tsx
+++ b/src/modules/bits/pages/BitsIndicateNow.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import { ReferralForm } from '@modules/bits/components/ReferralForm';
-import { ReferralLink } from '@modules/bits/components/ReferralLink';
+import { ReferralForm } from '@modules/bits/components/components/ReferralForm';
+import { ReferralLink } from '@modules/bits/components/components/ReferralLink';
 import { useAuth } from '@/context/AuthContext';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';

--- a/src/modules/bits/pages/BitsMyReferrals.tsx
+++ b/src/modules/bits/pages/BitsMyReferrals.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import { ReferralsList } from '@modules/bits/components/ReferralsList';
-import { ReferralLink } from '@modules/bits/components/ReferralLink';
+import { ReferralsList } from '@modules/bits/components/components/ReferralsList';
+import { ReferralLink } from '@modules/bits/components/components/ReferralLink';
 import { useReferrals } from '@modules/bits/hooks/useBits';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/context/AuthContext';

--- a/src/modules/bits/pages/BitsPointsAndRewards.tsx
+++ b/src/modules/bits/pages/BitsPointsAndRewards.tsx
@@ -1,11 +1,11 @@
 
 import React, { useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { PointsDisplay } from '@modules/bits/components/PointsDisplay';
-import { PointsHistory } from '@modules/bits/components/PointsHistory';
-import { RewardsList } from '@modules/bits/components/RewardsList';
-import { LevelProgress } from '@modules/bits/components/LevelProgress';
-import { UserBadgesList } from '@modules/bits/components/UserBadgesList';
+import { PointsDisplay } from '@modules/bits/components/components/PointsDisplay';
+import { PointsHistory } from '@modules/bits/components/components/PointsHistory';
+import { RewardsList } from '@modules/bits/components/components/RewardsList';
+import { LevelProgress } from '@modules/bits/components/components/LevelProgress';
+import { UserBadgesList } from '@modules/bits/components/components/UserBadgesList';
 import { usePoints, useRewards, useBadges, useLevels } from '@modules/bits/hooks/useBits';
 import { useAuth } from '@/context/AuthContext';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';

--- a/src/modules/bits/pages/BitsSettings.tsx
+++ b/src/modules/bits/pages/BitsSettings.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { ReferralLink } from '@modules/bits/components/ReferralLink';
+import { ReferralLink } from '@modules/bits/components/components/ReferralLink';
 import { useBitsProfile } from '@modules/bits/hooks/useBits';
 import { useAuth } from '@/context/AuthContext';
 import { Link } from 'react-router-dom';

--- a/src/modules/clients/components/clients/ClientsListView.tsx
+++ b/src/modules/clients/components/clients/ClientsListView.tsx
@@ -1,9 +1,9 @@
 
 import React, { useState } from 'react';
-import { ClientsFilters } from '@modules/clients/components/ClientsFilters';
-import { ClientsTable } from '@modules/clients/components/ClientsTable';
-import { ClientsEmptyState } from '@modules/clients/components/ClientsEmptyState';
-import { ClientEditDialog } from '@modules/clients/components/ClientEditDialog';
+import { ClientsFilters } from '@modules/clients/components/clients/ClientsFilters';
+import { ClientsTable } from '@modules/clients/components/clients/ClientsTable';
+import { ClientsEmptyState } from '@modules/clients/components/clients/ClientsEmptyState';
+import { ClientEditDialog } from '@modules/clients/components/clients/ClientEditDialog';
 
 interface Client {
   uuid: string;

--- a/src/modules/clients/pages/Clients.tsx
+++ b/src/modules/clients/pages/Clients.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import { StandardPageHeader } from '@/components/ui/standard-page-header';
 import { FileUser } from 'lucide-react';
-import { ClientsLoadingState } from '@modules/clients/components/ClientsLoadingState';
-import { ClientsErrorState } from '@modules/clients/components/ClientsErrorState';
-import { ClientsActions } from '@modules/clients/components/ClientsActions';
-import { ClientsListView } from '@modules/clients/components/ClientsListView';
+import { ClientsLoadingState } from '@modules/clients/components/clients/ClientsLoadingState';
+import { ClientsErrorState } from '@modules/clients/components/clients/ClientsErrorState';
+import { ClientsActions } from '@modules/clients/components/clients/ClientsActions';
+import { ClientsListView } from '@modules/clients/components/clients/ClientsListView';
 import { useClientsData } from '@modules/clients/hooks/useClientsData';
 
 const Clients = () => {

--- a/src/modules/dashboard/components/dashboard/FilteredAssetsTable.tsx
+++ b/src/modules/dashboard/components/dashboard/FilteredAssetsTable.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { AssetFilterValues } from '@modules/dashboard/components/AssetFilters';
+import { AssetFilterValues } from '@modules/dashboard/components/dashboard/AssetFilters';
 import { formatRelativeTime } from '@/utils/dashboardUtils';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';

--- a/src/modules/dashboard/hooks/useDashboardWithFilters.ts
+++ b/src/modules/dashboard/hooks/useDashboardWithFilters.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useDashboardStats, DashboardStats } from '@modules/dashboard/hooks/useDashboardStats';
-import { AssetFilterValues } from '@modules/dashboard/components/AssetFilters';
+import { AssetFilterValues } from '@modules/dashboard/components/dashboard/AssetFilters';
 
 interface UseDashboardWithFiltersResult {
   dashboardStats: DashboardStats | undefined;

--- a/src/modules/dashboard/pages/Dashboard.tsx
+++ b/src/modules/dashboard/pages/Dashboard.tsx
@@ -7,12 +7,12 @@ import { useDashboardAssets } from '@modules/dashboard/hooks/useDashboardAssets'
 import { useDashboardAssociationsDetailed } from '@modules/dashboard/hooks/useDashboardAssociationsDetailed';
 import { useDashboardStatusByType } from '@modules/dashboard/hooks/useDashboardStatusByType';
 import { useDashboardRecentActivities } from '@modules/dashboard/hooks/useDashboardRecentActivities';
-import { AssetSummaryCard } from '@modules/dashboard/components/AssetSummaryCard';
-import { RentalAssociationsCard } from '@modules/dashboard/components/RentalAssociationsCard';
-import { SubscriptionAssociationsCard } from '@modules/dashboard/components/SubscriptionAssociationsCard';
-import { AssetTypeStatusChart } from '@modules/dashboard/components/AssetTypeStatusChart';
-import { QuickActionsCard } from '@modules/dashboard/components/QuickActionsCard';
-import { RecentActivitiesCard } from '@modules/dashboard/components/RecentActivitiesCard';
+import { AssetSummaryCard } from '@modules/dashboard/components/dashboard/AssetSummaryCard';
+import { RentalAssociationsCard } from '@modules/dashboard/components/dashboard/RentalAssociationsCard';
+import { SubscriptionAssociationsCard } from '@modules/dashboard/components/dashboard/SubscriptionAssociationsCard';
+import { AssetTypeStatusChart } from '@modules/dashboard/components/dashboard/AssetTypeStatusChart';
+import { QuickActionsCard } from '@modules/dashboard/components/dashboard/QuickActionsCard';
+import { RecentActivitiesCard } from '@modules/dashboard/components/dashboard/RecentActivitiesCard';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 const Dashboard = () => {

--- a/src/modules/data-usage/pages/DataUsage.tsx
+++ b/src/modules/data-usage/pages/DataUsage.tsx
@@ -4,12 +4,12 @@ import { useDataUsage } from "@/context/DataUsageContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { ChipWithMetrics, TimeRange, GroupByOption } from "@/types/dataUsage";
-import { UsageFilters } from "@/components/data-usage/UsageFilters";
-import { UsageChart } from "@/components/data-usage/UsageChart";
-import { ChipSummaryCards } from "@/components/data-usage/ChipSummaryCards";
-import { UsageMetricCards } from "@/components/data-usage/UsageMetricCards";
-import { UsageHeader } from "@/components/data-usage/UsageHeader";
-import { useChipDataGrouping } from "@/hooks/useChipDataGrouping";
+import { UsageFilters } from "@modules/data-usage/components/data-usage/UsageFilters";
+import { UsageChart } from "@modules/data-usage/components/data-usage/UsageChart";
+import { ChipSummaryCards } from "@modules/data-usage/components/data-usage/ChipSummaryCards";
+import { UsageMetricCards } from "@modules/data-usage/components/data-usage/UsageMetricCards";
+import { UsageHeader } from "@modules/data-usage/components/data-usage/UsageHeader";
+import { useChipDataGrouping } from "@modules/data-usage/hooks/useChipDataGrouping";
 
 export default function DataUsage() {
   const { 

--- a/src/modules/inventory/components/inventory/InventoryFilters.tsx
+++ b/src/modules/inventory/components/inventory/InventoryFilters.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { StatusRecord } from "@/types/asset";
-import { useAssetSolutions } from "@/hooks/useAssetSolutions";
+import { useAssetSolutions } from "@modules/assets/hooks/useAssetSolutions";
 
 interface InventoryFiltersProps {
   search: string;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,14 +5,14 @@ import { Loader2, AlertTriangle } from "lucide-react";
 import { useDashboardAssets } from "@modules/dashboard/hooks/useDashboardAssets";
 import { useDashboardStats } from "@modules/dashboard/hooks/useDashboardStats";
 import { useDashboardRecentActivities } from "@modules/dashboard/hooks/useDashboardRecentActivities";
-import { StatsSummaryCard } from "@modules/dashboard/components/StatsSummaryCard";
-import { StatusCard } from "@modules/dashboard/components/StatusCard";
+import { StatsSummaryCard } from "@modules/dashboard/components/dashboard/StatsSummaryCard";
+import { StatusCard } from "@modules/dashboard/components/dashboard/StatusCard";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { LeaseAssetsCard } from "@modules/dashboard/components/LeaseAssetsCard";
-import { SubscriptionAssetsCard } from "@modules/dashboard/components/SubscriptionAssetsCard";
-import { RecentActivitiesCard } from "@/components/dashboard/RecentActivitiesCard";
-import { RefactoredAssetStatusDistributionCard } from "@/components/dashboard/RefactoredAssetStatusDistributionCard";
-import { SyncStatusAlert } from "@/components/dashboard/SyncStatusAlert";
+import { LeaseAssetsCard } from "@modules/dashboard/components/dashboard/LeaseAssetsCard";
+import { SubscriptionAssetsCard } from "@modules/dashboard/components/dashboard/SubscriptionAssetsCard";
+import { RecentActivitiesCard } from "@modules/dashboard/components/dashboard/RecentActivitiesCard";
+import { RefactoredAssetStatusDistributionCard } from "@modules/dashboard/components/dashboard/RefactoredAssetStatusDistributionCard";
+import { SyncStatusAlert } from "@modules/dashboard/components/dashboard/SyncStatusAlert";
 import { useIsMobile } from "@/hooks/useIsMobile";
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@modules": path.resolve(__dirname, "./src/modules"),
     },
   },
 }));


### PR DESCRIPTION
## Summary
- configure `@modules` alias for vite so imports resolve correctly
- update imports for moved components and hooks

## Testing
- `npm run lint` *(fails: several eslint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68419eee6e988325b46c455385268648