### PR TITLE
Add manufacturer filter to assets search

### DIFF
--- a/src/modules/assets/components/assets/AssetsSearchForm.tsx
+++ b/src/modules/assets/components/assets/AssetsSearchForm.tsx
@@ -6,12 +6,14 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent } from '@/components/ui/card';
 import { useAssetSolutions } from '@modules/assets/hooks/useAssetSolutions';
+import { useManufacturers } from '@modules/assets/hooks/useAssetManagement';
 
 interface AssetsSearchFormProps {
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   filterType: string;
   filterStatus: string;
+  filterManufacturer: string;
   handleSearch: (e: React.FormEvent) => void;
   handleFilterChange: (type: string, value: string) => void;
   isSearching?: boolean;
@@ -22,6 +24,7 @@ const AssetsSearchForm = ({
   setSearchTerm,
   filterType,
   filterStatus,
+  filterManufacturer,
   handleSearch,
   handleFilterChange,
   isSearching = false
@@ -29,11 +32,14 @@ const AssetsSearchForm = ({
   
   // Hook para buscar soluções dinamicamente
   const { data: assetSolutions = [], isLoading: loadingSolutions } = useAssetSolutions();
+  // Hook para buscar fabricantes dinamicamente
+  const { data: manufacturers = [], isLoading: loadingManufacturers } = useManufacturers();
   
   const handleReset = () => {
     setSearchTerm('');
     handleFilterChange('type', 'all');
     handleFilterChange('status', 'all');
+    handleFilterChange('manufacturer', 'all');
   };
 
   // Placeholder responsivo baseado no tamanho da tela
@@ -80,7 +86,7 @@ const AssetsSearchForm = ({
             </div>
 
             {/* Filtros com grid responsivo */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-4">
               {/* Filtro por Tipo - Dinâmico */}
               <div className="space-y-2">
                 <label className="text-sm font-bold text-legal-dark font-neue-haas flex items-center gap-2">
@@ -136,6 +142,32 @@ const AssetsSearchForm = ({
                     <SelectItem value="SEM DADOS" className="font-neue-haas">⚠️ Sem Dados</SelectItem>
                     <SelectItem value="BLOQUEADO" className="font-neue-haas">🚫 Bloqueado</SelectItem>
                     <SelectItem value="EM MANUTENÇÃO" className="font-neue-haas">🔧 Em Manutenção</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Filtro por Fabricante */}
+              <div className="space-y-2">
+                <label className="text-sm font-bold text-legal-dark font-neue-haas flex items-center gap-2">
+                  <Filter className="h-4 w-4 text-legal-secondary" />
+                  <span className="hidden sm:inline">Fabricante</span>
+                  <span className="sm:hidden">Marca</span>
+                </label>
+                <Select
+                  value={filterManufacturer}
+                  onValueChange={(value) => handleFilterChange('manufacturer', value)}
+                  disabled={loadingManufacturers}
+                >
+                  <SelectTrigger className="h-12 border-legal-secondary/30 focus:border-legal-secondary font-neue-haas">
+                    <SelectValue placeholder={loadingManufacturers ? 'Carregando...' : 'Todos os fabricantes'} />
+                  </SelectTrigger>
+                  <SelectContent className="bg-white border-legal-secondary/20">
+                    <SelectItem value="all" className="font-neue-haas">Todos os Fabricantes</SelectItem>
+                    {manufacturers.map((manu) => (
+                      <SelectItem key={manu.id} value={manu.id.toString()} className="font-neue-haas">
+                        {manu.name}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/src/modules/assets/hooks/useAssetsData.ts
+++ b/src/modules/assets/hooks/useAssetsData.ts
@@ -53,6 +53,7 @@ export interface UseAssetsDataParams {
   searchTerm?: string;
   filterType?: string;
   filterStatus?: string;
+  filterManufacturer?: string;
   currentPage?: number;
   pageSize?: number;
   enabled?: boolean;
@@ -111,12 +112,13 @@ export const useAssetsData = ({
   searchTerm = '',
   filterType = 'all',
   filterStatus = 'all',
+  filterManufacturer = 'all',
   currentPage = 1,
   pageSize = 10,
   enabled = true
 }: UseAssetsDataParams = {}) => {
   return useQuery({
-    queryKey: ['assets', 'inventory', filterType, filterStatus, searchTerm, currentPage],
+    queryKey: ['assets', 'inventory', filterType, filterStatus, filterManufacturer, searchTerm, currentPage],
     queryFn: async (): Promise<AssetsDataResponse> => {
       try {
         console.log('Iniciando busca de assets com termo:', searchTerm);
@@ -179,6 +181,22 @@ export const useAssetsData = ({
 
           if (statusData) {
             query = query.eq('status_id', statusData.id);
+          }
+        }
+
+        if (filterManufacturer !== 'all') {
+          if (!isNaN(Number(filterManufacturer))) {
+            query = query.eq('manufacturer_id', Number(filterManufacturer));
+          } else {
+            const { data: manufacturerData } = await supabase
+              .from('manufacturers')
+              .select('id')
+              .ilike('name', filterManufacturer)
+              .single();
+
+            if (manufacturerData) {
+              query = query.eq('manufacturer_id', manufacturerData.id);
+            }
           }
         }
 
@@ -287,6 +305,12 @@ export const useAssetsData = ({
 
           if (statusData) {
             countQuery = countQuery.eq('status_id', statusData.id);
+          }
+        }
+
+        if (filterManufacturer !== 'all') {
+          if (!isNaN(Number(filterManufacturer))) {
+            countQuery = countQuery.eq('manufacturer_id', Number(filterManufacturer));
           }
         }
 

--- a/src/modules/assets/pages/AssetsInventory.tsx
+++ b/src/modules/assets/pages/AssetsInventory.tsx
@@ -16,6 +16,7 @@ const AssetsInventory = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterType, setFilterType] = useState("all");
   const [filterStatus, setFilterStatus] = useState("all");
+  const [filterManufacturer, setFilterManufacturer] = useState("all");
   const [currentPage, setCurrentPage] = useState(1);
   const [shouldFetch, setShouldFetch] = useState(true);
   
@@ -35,6 +36,7 @@ const AssetsInventory = () => {
     searchTerm: debouncedSearchTerm, // Usa o termo com debounce
     filterType,
     filterStatus,
+    filterManufacturer,
     currentPage,
     pageSize: ASSETS_PER_PAGE,
     enabled: shouldFetch
@@ -66,6 +68,8 @@ const AssetsInventory = () => {
       setFilterType(value);
     } else if (type === 'status') {
       setFilterStatus(value);
+    } else if (type === 'manufacturer') {
+      setFilterManufacturer(value);
     }
   }, []);
 
@@ -90,7 +94,7 @@ const AssetsInventory = () => {
   }, [queryClient, refetch]);
   
   // Mostra loading apenas no carregamento inicial, não durante debounce
-  if (isLoading && !debouncedSearchTerm && filterType === 'all' && filterStatus === 'all') {
+  if (isLoading && !debouncedSearchTerm && filterType === 'all' && filterStatus === 'all' && filterManufacturer === 'all') {
     return <AssetsLoading />;
   }
   
@@ -115,11 +119,12 @@ const AssetsInventory = () => {
     <div className="container mx-auto px-4 md:px-6 space-y-4 md:space-y-6">
       <AssetsHeader />
       
-      <AssetsSearchForm 
+      <AssetsSearchForm
         searchTerm={searchTerm}
         setSearchTerm={handleSearchTermChange}
         filterType={filterType}
         filterStatus={filterStatus}
+        filterManufacturer={filterManufacturer}
         handleSearch={handleSearch}
         handleFilterChange={handleFilterChange}
         isSearching={isSearching}


### PR DESCRIPTION
## Summary
- extend search form to include manufacturer filter
- wire new filter through AssetsInventory page
- support manufacturer filter in useAssetsData

## Testing
- `npm run lint` *(fails: 191 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6841adfa551c832595ba4253df9ea41b