### PR TITLE
Add client registration page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import AssetsManagement from "@modules/assets/pages/AssetsManagement";
 import AssetAssociation from "@modules/associations/pages/AssetAssociation";
 import AssociationsList from "@modules/associations/pages/AssociationsList";
 import Clients from "@modules/clients/pages/Clients";
+import RegisterClient from "@modules/clients/pages/RegisterClient";
 import Association from "@modules/associations/pages/Association";
 import Subscriptions from "./pages/Subscriptions";
 import Monitoring from "./pages/Monitoring";
@@ -135,6 +136,7 @@ const App = () => (
                     <Route path="/inventory" element={<Navigate to="/assets/inventory" replace />} />
                     <Route path="/history" element={<Navigate to="/assets/history" replace />} />
                     <Route path="/clients" element={<Clients />} />
+                    <Route path="/clients/register" element={<RegisterClient />} />
                     <Route path="/suppliers" element={<Suppliers />} />
                     <Route path="/association" element={<Navigate to="/assets/association" replace />} />
                     <Route path="/subscriptions" element={<Subscriptions />} />

--- a/src/modules/clients/components/clients/ClientsActions.tsx
+++ b/src/modules/clients/components/clients/ClientsActions.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
 import { Plus, Download } from 'lucide-react';
 import { exportClientsToCSV } from '@/utils/clientsExport';
 import { toast } from 'sonner';
@@ -26,6 +27,7 @@ export const ClientsActions: React.FC<ClientsActionsProps> = ({
   clients,
   filteredClients
 }) => {
+  const navigate = useNavigate();
   // Função para exportar CSV
   const handleExportCSV = () => {
     try {
@@ -40,7 +42,10 @@ export const ClientsActions: React.FC<ClientsActionsProps> = ({
 
   return (
     <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto">
-      <Button className="bg-[#4D2BFB] text-white hover:bg-[#3a1ecc] focus:ring-[#4D2BFB] flex items-center gap-2 w-full sm:w-auto h-10 sm:h-9 text-sm">
+      <Button
+        className="bg-[#4D2BFB] text-white hover:bg-[#3a1ecc] focus:ring-[#4D2BFB] flex items-center gap-2 w-full sm:w-auto h-10 sm:h-9 text-sm"
+        onClick={() => navigate('/clients/register')}
+      >
         <Plus className="h-4 w-4" />
         Novo Cliente
       </Button>

--- a/src/modules/clients/pages/RegisterClient.tsx
+++ b/src/modules/clients/pages/RegisterClient.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { ArrowLeft, Users } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { StandardPageHeader } from '@/components/ui/standard-page-header';
+import { StandardFiltersCard } from '@/components/ui/standard-filters-card';
+import { ClientForm } from '@modules/associations/components/association/ClientForm';
+import { Client } from '@/types/client';
+
+const RegisterClient: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleCancel = () => {
+    navigate('/clients');
+  };
+
+  const handleSubmit = (client: Client) => {
+    navigate('/clients');
+  };
+
+  return (
+    <div className="space-y-6">
+      <StandardPageHeader
+        icon={Users}
+        title="Cadastrar Cliente"
+        description="Insira as informações do novo cliente"
+      >
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate(-1)}
+          className="flex items-center gap-2 text-[#4D2BFB] hover:bg-[#4D2BFB]/10 font-neue-haas"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Voltar
+        </Button>
+      </StandardPageHeader>
+      <StandardFiltersCard title="Dados do Cliente">
+        <ClientForm onSubmit={handleSubmit} onCancel={handleCancel} />
+      </StandardFiltersCard>
+    </div>
+  );
+};
+
+export default RegisterClient;


### PR DESCRIPTION
## Summary
- create RegisterClient page for creating clients
- add route `/clients/register`
- update client actions to link to registration page

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6841b18742748325804899eb622a768c