### PR TITLE
Add logout support in Header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 
 import React from "react";
+import { useAuth } from "@/context/AuthContext";
 import { ThemeToggle } from "../auth/ThemeToggle";
 import { Button } from "@/components/ui/button";
 import { 
@@ -26,6 +27,8 @@ interface HeaderProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 export function Header({ children, className, ...props }: HeaderProps) {
+  const { signOut } = useAuth();
+
   return (
     <header 
       className={cn(
@@ -80,7 +83,10 @@ export function Header({ children, className, ...props }: HeaderProps) {
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator className="bg-legal-primary/20 dark:bg-legal-secondary/20" />
-            <DropdownMenuItem className="hover:bg-destructive/10 focus:bg-destructive/10 text-destructive">
+            <DropdownMenuItem
+              onClick={signOut}
+              className="hover:bg-destructive/10 focus:bg-destructive/10 text-destructive"
+            >
               <LogOut className="mr-2 h-4 w-4" />
               <span>Sair</span>
             </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- hook Header to auth context
- trigger logout when clicking "Sair"

## Testing
- `npm run lint` *(fails: 224 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68482d7128e88325b587004aad46dd78