### PR TITLE
Implement updated role hierarchy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,12 +162,12 @@ const App = () => (
                       <Route path="new" element={<NewTicket />} />
                       <Route path="knowledge-base" element={<KnowledgeBase />} />
                       <Route path="automation" element={
-                        <AuthRoute requiredRole="consultor">
+                        <AuthRoute requiredRole="suporte">
                           <TicketAutomation />
                         </AuthRoute>
                       } />
                       <Route path="analytics" element={
-                        <AuthRoute requiredRole="consultor">
+                        <AuthRoute requiredRole="suporte">
                           <TicketAnalytics />
                         </AuthRoute>
                       } />
@@ -182,7 +182,7 @@ const App = () => (
                         </AuthRoute>
                       } />
                       <Route path="integrations" element={
-                        <AuthRoute requiredRole="gestor">
+                        <AuthRoute requiredRole="admin">
                           <TicketIntegrations />
                         </AuthRoute>
                       } />
@@ -246,9 +246,9 @@ const App = () => (
                       </AuthRoute>
                     } />
                     
-                    {/* Admin/Management routes - Requires gestor or above */}
+                    {/* Admin/Management routes - Requires admin */}
                     <Route path="/suppliers" element={
-                      <AuthRoute requiredRole="gestor">
+                      <AuthRoute requiredRole="admin">
                         <Suppliers />
                       </AuthRoute>
                     } />

--- a/src/components/layout/sidebar/StaticNavigation.tsx
+++ b/src/components/layout/sidebar/StaticNavigation.tsx
@@ -98,14 +98,14 @@ export function StaticNavigation({
           icon={Zap}
           label="Automação e Regras"
           onClose={isMobile ? onClose : undefined}
-          requiredRole="consultor"
+          requiredRole="suporte"
         />
         <NavigationItem
           to="/tickets/analytics"
           icon={TrendingUp}
           label="Análises & Relatórios"
           onClose={isMobile ? onClose : undefined}
-          requiredRole="consultor"
+          requiredRole="suporte"
         />
         <NavigationItem
           to="/tickets/quality"
@@ -126,7 +126,7 @@ export function StaticNavigation({
           icon={Puzzle}
           label="Integrações"
           onClose={isMobile ? onClose : undefined}
-          requiredRole="gestor"
+          requiredRole="admin"
         />
       </div>
 
@@ -179,7 +179,7 @@ export function StaticNavigation({
         />
       </div>
 
-      {/* Admin Section - Requires gestor or above */}
+      {/* Admin Section - Requires admin */}
       <div className="flex flex-col space-y-2">
         <div className="px-3 mb-1">
           <h3 className="text-xs font-medium uppercase tracking-wider text-sidebar-foreground/70">Administração</h3>
@@ -189,7 +189,7 @@ export function StaticNavigation({
           icon={Boxes}
           label="Fornecedores"
           onClose={isMobile ? onClose : undefined}
-          requiredRole="gestor"
+          requiredRole="admin"
         />
         <NavigationItem
           to="/admin"

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -26,40 +26,32 @@ export const AUTH_ERROR_MESSAGES = {
 
 // Hierarquia de roles para controle de acesso
 export const ROLE_HIERARCHY = {
-  admin: 5,
-  gestor: 4,
-  consultor: 3,
+  admin: 3,
   suporte: 2,
   cliente: 1,
-  user: 0
+  usuario: 0
 } as const;
 
 // Labels amigáveis para os roles
 export const ROLE_LABELS = {
   admin: 'Administrador',
-  gestor: 'Gestor',
-  consultor: 'Consultor',
   suporte: 'Suporte',
   cliente: 'Cliente',
-  user: 'Usuário'
+  usuario: 'Usuário'
 } as const;
 
 // Descrições dos roles
 export const ROLE_DESCRIPTIONS = {
   admin: 'Acesso total ao sistema, incluindo configurações avançadas',
-  gestor: 'Gerenciamento de equipes e recursos do sistema',
-  consultor: 'Consultoria e análise de dados dos clientes',
   suporte: 'Suporte técnico e atendimento ao cliente',
   cliente: 'Acesso aos recursos básicos do sistema',
-  user: 'Acesso limitado ao sistema'
+  usuario: 'Acesso limitado ao sistema'
 } as const;
 
 // Cores para badges de role
 export const ROLE_COLORS = {
   admin: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-  gestor: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
-  consultor: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   suporte: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
   cliente: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  user: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400'
+  usuario: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400'
 } as const;

--- a/src/hooks/useAuthActions.ts
+++ b/src/hooks/useAuthActions.ts
@@ -62,7 +62,7 @@ export function useAuthActions(updateState: (state: any) => void) {
       });
       
       // Ensure we have a valid role
-      if (!['admin', 'gestor', 'consultor', 'suporte', 'cliente', 'user'].includes(role)) {
+      if (!['admin', 'suporte', 'cliente', 'usuario'].includes(role)) {
         console.warn(`Role inválido '${role}' fornecido, usando '${DEFAULT_USER_ROLE}' como padrão`);
         role = DEFAULT_USER_ROLE as UserRole;
       }

--- a/src/hooks/useAuthSession.ts
+++ b/src/hooks/useAuthSession.ts
@@ -34,7 +34,7 @@ export function useAuthSession(updateState: (state: any) => void) {
         if (profile) {
           console.log('Profile fetched successfully:', profile.email);
           // Verificar se o role está entre os valores esperados
-          if (!['admin', 'gestor', 'consultor', 'suporte', 'cliente', 'user'].includes(profile.role)) {
+          if (!['admin', 'suporte', 'cliente', 'usuario'].includes(profile.role)) {
             console.warn(`Invalid role detected: ${profile.role}, defaulting to 'cliente'`);
             profile.role = 'cliente';
           }

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -27,21 +27,21 @@ export const usePermissions = () => {
     canViewClients: hasMinimumRole('suporte'),
     canCreateClients: hasMinimumRole('suporte'),
     canEditClients: hasMinimumRole('suporte'),
-    canDeleteClients: hasMinimumRole('consultor'),
+    canDeleteClients: hasMinimumRole('suporte'),
     
     // Gestão de ativos
     canViewAssets: hasMinimumRole('suporte'),
     canCreateAssets: hasMinimumRole('suporte'),
     canEditAssets: hasMinimumRole('suporte'),
-    canDeleteAssets: hasMinimumRole('consultor'),
+    canDeleteAssets: hasMinimumRole('suporte'),
     canManageAssociations: hasMinimumRole('suporte'),
     
     // Relatórios e análises
-    canViewReports: hasMinimumRole('consultor'),
-    canExportData: hasMinimumRole('consultor'),
+    canViewReports: hasMinimumRole('suporte'),
+    canExportData: hasMinimumRole('suporte'),
     
     // Administração
-    canManageUsers: hasMinimumRole('gestor'),
+    canManageUsers: hasMinimumRole('admin'),
     canAccessAdminPanel: hasMinimumRole('admin'),
     canModifySystemSettings: hasMinimumRole('admin'),
     

--- a/src/hooks/useRolePermissions.ts
+++ b/src/hooks/useRolePermissions.ts
@@ -2,25 +2,21 @@
 import { useMemo } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { UserRole } from '@/types/auth';
-import { 
-  hasMinimumRole, 
-  isSupportOrAbove, 
-  isClienteOrAbove, 
-  isConsultorOrAbove, 
-  isGestorOrAbove, 
+import {
+  hasMinimumRole,
+  isSupportOrAbove,
+  isClienteOrAbove,
   isAdmin,
   getAssignableRoles
 } from '@/utils/roleUtils';
 
 export const useRolePermissions = () => {
   const { profile } = useAuth();
-  const userRole = profile?.role || 'user';
+  const userRole = profile?.role || 'usuario';
 
   const permissions = useMemo(() => ({
     // Verificações básicas de role
     isAdmin: isAdmin(userRole),
-    isGestorOrAbove: isGestorOrAbove(userRole),
-    isConsultorOrAbove: isConsultorOrAbove(userRole),
     isSupportOrAbove: isSupportOrAbove(userRole),
     isClienteOrAbove: isClienteOrAbove(userRole),
     
@@ -34,11 +30,11 @@ export const useRolePermissions = () => {
     currentRole: userRole,
     
     // Permissões específicas do sistema
-    canManageUsers: isGestorOrAbove(userRole),
+    canManageUsers: isAdmin(userRole),
     canAccessAdminPanel: isAdmin(userRole),
     canProvideSupport: isSupportOrAbove(userRole),
-    canManageAssets: isConsultorOrAbove(userRole),
-    canViewReports: isConsultorOrAbove(userRole),
+    canManageAssets: isSupportOrAbove(userRole),
+    canViewReports: isSupportOrAbove(userRole),
     canManageClients: isSupportOrAbove(userRole),
     canAccessBits: isClienteOrAbove(userRole),
     canGenerateReferrals: isClienteOrAbove(userRole)

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1291,11 +1291,9 @@ export type Database = {
         | "LOAD BALANCE"
       user_role_enum:
         | "admin"
-        | "gestor"
-        | "consultor"
-        | "cliente"
-        | "user"
         | "suporte"
+        | "cliente"
+        | "usuario"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1442,11 +1440,9 @@ export const Constants = {
       ],
       user_role_enum: [
         "admin",
-        "gestor",
-        "consultor",
-        "cliente",
-        "user",
         "suporte",
+        "cliente",
+        "usuario",
       ],
     },
   },

--- a/src/modules/bits/pages/BitsSettings.tsx
+++ b/src/modules/bits/pages/BitsSettings.tsx
@@ -60,7 +60,7 @@ const BitsSettings: React.FC = () => {
                 <Label htmlFor="role">Função</Label>
                 <Input 
                   id="role" 
-                  value={profile?.role || 'user'} 
+                  value={profile?.role || 'usuario'}
                   disabled
                 />
               </div>

--- a/src/modules/bits/services/bitsService.ts
+++ b/src/modules/bits/services/bitsService.ts
@@ -461,7 +461,7 @@ export const bitsProfileService = {
       
       // Only generate codes for cliente or higher roles (including suporte)
       const role = profile?.role as UserRole;
-      if (role !== 'cliente' && role !== 'suporte' && role !== 'gestor' && role !== 'admin' && role !== 'consultor') {
+      if (role !== 'cliente' && role !== 'suporte' && role !== 'admin') {
         throw new Error("Only 'cliente' or higher roles can generate referral codes");
       }
       

--- a/src/modules/clients/components/clients/ClientsActions.tsx
+++ b/src/modules/clients/components/clients/ClientsActions.tsx
@@ -55,7 +55,7 @@ export const ClientsActions: React.FC<ClientsActionsProps> = ({
         </Button>
       </RoleGuard>
 
-      <RoleGuard requiredRole="consultor">
+      <RoleGuard requiredRole="suporte">
         <Button 
           variant="outline" 
           className="border-[#03F9FF] text-[#020CBC] hover:bg-[#03F9FF]/10 focus:ring-[#03F9FF] flex items-center gap-2 w-full sm:w-auto h-10 sm:h-9 text-sm"

--- a/src/modules/dashboard/components/dashboard/QuickActionsCard.tsx
+++ b/src/modules/dashboard/components/dashboard/QuickActionsCard.tsx
@@ -112,7 +112,7 @@ export const QuickActionsCard: React.FC = () => {
           </Button>
         </RoleGuard>
 
-        <RoleGuard requiredRole="consultor">
+        <RoleGuard requiredRole="suporte">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -75,7 +75,7 @@ export const authService = {
     console.log('Iniciando processo de cadastro:', { email, role });
     
     // Ensure role is one of the valid enum values
-    if (!['admin', 'gestor', 'consultor', 'suporte', 'cliente', 'user'].includes(role)) {
+    if (!['admin', 'suporte', 'cliente', 'usuario'].includes(role)) {
       console.warn(`Valor de role inválido: ${role}, usando '${DEFAULT_USER_ROLE}' como padrão`);
       role = DEFAULT_USER_ROLE as UserRole;
     }

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -24,7 +24,7 @@ export const profileService = {
         
         // Validate the role to ensure it's one of the valid values
         const role = data.role as UserRole;
-        if (!['admin', 'gestor', 'consultor', 'suporte', 'cliente', 'user'].includes(role)) {
+        if (!['admin', 'suporte', 'cliente', 'usuario'].includes(role)) {
           console.warn(`Invalid role found for user ${userId}: ${role}, defaulting to 'cliente'`);
           data.role = 'cliente';
         }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,7 +1,7 @@
 
 import { User } from '@supabase/supabase-js';
 
-export type UserRole = 'admin' | 'gestor' | 'consultor' | 'suporte' | 'cliente' | 'user';
+export type UserRole = 'admin' | 'suporte' | 'cliente' | 'usuario';
 
 export interface UserProfile {
   id: string;

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -26,20 +26,6 @@ export const isClienteOrAbove = (userRole: UserRole): boolean => {
 };
 
 /**
- * Verifica se o usuário é consultor ou superior
- */
-export const isConsultorOrAbove = (userRole: UserRole): boolean => {
-  return hasMinimumRole(userRole, 'consultor');
-};
-
-/**
- * Verifica se o usuário é gestor ou superior
- */
-export const isGestorOrAbove = (userRole: UserRole): boolean => {
-  return hasMinimumRole(userRole, 'gestor');
-};
-
-/**
  * Verifica se o usuário é admin
  */
 export const isAdmin = (userRole: UserRole): boolean => {
@@ -64,7 +50,7 @@ export const getRoleDescription = (role: UserRole): string => {
  * Obtém as classes CSS para o badge do role
  */
 export const getRoleColors = (role: UserRole): string => {
-  return ROLE_COLORS[role] || ROLE_COLORS.user;
+  return ROLE_COLORS[role] || ROLE_COLORS.usuario;
 };
 
 /**


### PR DESCRIPTION
## Summary
- add new roles `usuario`, `cliente`, `suporte` and `admin`
- simplify role utilities and permissions logic
- update sidebar and routes for new role levels
- adjust signup and profile services for new roles

## Testing
- `npm run lint` *(fails: 228 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68486a2c31a8832589e915592cba3de4