### PR TITLE
Add admin config page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Layout } from "@/components/layout/Layout";
 import { DataUsageProvider } from "@/context/DataUsageContext";
 import { AuthProvider } from "@/context/AuthContext";
 import { AuthRoute } from "@/components/auth/AuthRoute";
+import { PrivateRoute } from "@/components/auth/PrivateRoute";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 // Pages
@@ -33,6 +34,8 @@ import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import NotFound from "./pages/NotFound";
 import Suppliers from "./pages/Suppliers";
+import AdminConfig from "./pages/AdminConfig";
+import Unauthorized from "./pages/Unauthorized";
 import Topology from "./pages/Topology";
 import Discovery from "./pages/Discovery";
 
@@ -88,6 +91,7 @@ const App = () => (
                   {/* Public authentication routes */}
                   <Route path="/login" element={<Login />} />
                   <Route path="/signup" element={<Signup />} />
+                  <Route path="/unauthorized" element={<Unauthorized />} />
                   
                   {/* Main layout with sidebar and header - Protected routes */}
                   <Route path="/" element={
@@ -247,10 +251,17 @@ const App = () => (
                     } />
                     
                     {/* Admin/Management routes - Requires gestor or above */}
+
                     <Route path="/suppliers" element={
                       <AuthRoute requiredRole="gestor">
                         <Suppliers />
                       </AuthRoute>
+                    } />
+
+                    <Route path="/admin/config" element={
+                      <PrivateRoute requiredRole="admin">
+                        <AdminConfig />
+                      </PrivateRoute>
                     } />
                     
                     {/* Direct shortcuts */}

--- a/src/components/auth/PrivateRoute.tsx
+++ b/src/components/auth/PrivateRoute.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
+import { UserRole } from '@/types/auth';
+
+interface PrivateRouteProps {
+  children: ReactNode;
+  requiredRole?: UserRole;
+}
+
+export const PrivateRoute = ({ children, requiredRole = 'admin' }: PrivateRouteProps) => {
+  const { isAuthenticated, hasMinimumRole, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (requiredRole && !hasMinimumRole(requiredRole)) {
+    return <Navigate to="/unauthorized" replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/pages/AdminConfig.tsx
+++ b/src/pages/AdminConfig.tsx
@@ -6,7 +6,18 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
-import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogFooter, AlertDialogCancel, AlertDialogAction, AlertDialogDescription } from '@/components/ui/alert-dialog';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+  AlertDialogDescription
+} from '@/components/ui/alert-dialog';
+import { Loader2 } from 'lucide-react';
 import { toast } from '@/utils/toast';
 import { UserRole } from '@/types/auth';
 import { formatDateForDisplay } from '@/utils/dateUtils';
@@ -106,10 +117,17 @@ const AdminConfig = () => {
                 <TableCell>{getRoleLabel(u.role)}</TableCell>
                 <TableCell>{formatDateForDisplay(u.created_at)}</TableCell>
                 <TableCell className="space-x-2">
-                  <Button size="sm" variant="outline" onClick={() => openEdit(u)}>Editar</Button>
+                  <Button size="sm" variant="outline" onClick={() => openEdit(u)} disabled={updateMutation.isLoading}>
+                    Editar
+                  </Button>
                   <AlertDialog>
                     <AlertDialogTrigger asChild>
-                      <Button size="sm" variant="destructive">Excluir</Button>
+                      <Button size="sm" variant="destructive" disabled={deleteMutation.isLoading}>
+                        {deleteMutation.isLoading ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : null}
+                        Excluir
+                      </Button>
                     </AlertDialogTrigger>
                     <AlertDialogContent>
                       <AlertDialogHeader>
@@ -119,8 +137,16 @@ const AdminConfig = () => {
                         </AlertDialogDescription>
                       </AlertDialogHeader>
                       <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                        <AlertDialogAction onClick={() => deleteMutation.mutate(u.id)}>Excluir</AlertDialogAction>
+                        <AlertDialogCancel disabled={deleteMutation.isLoading}>Cancelar</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => deleteMutation.mutate(u.id)}
+                          disabled={deleteMutation.isLoading}
+                        >
+                          {deleteMutation.isLoading ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : null}
+                          Excluir
+                        </AlertDialogAction>
                       </AlertDialogFooter>
                     </AlertDialogContent>
                   </AlertDialog>
@@ -160,8 +186,19 @@ const AdminConfig = () => {
             </Select>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setEditingUser(null)}>Cancelar</Button>
-            <Button onClick={handleSave} disabled={updateMutation.isLoading}>{updateMutation.isLoading ? 'Salvando...' : 'Salvar'}</Button>
+            <Button variant="outline" onClick={() => setEditingUser(null)} disabled={updateMutation.isLoading}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSave} disabled={updateMutation.isLoading}>
+              {updateMutation.isLoading ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Salvando...
+                </span>
+              ) : (
+                'Salvar'
+              )}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/pages/AdminConfig.tsx
+++ b/src/pages/AdminConfig.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { Table, TableHeader, TableHead, TableRow, TableCell, TableBody } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogFooter, AlertDialogCancel, AlertDialogAction, AlertDialogDescription } from '@/components/ui/alert-dialog';
+import { toast } from '@/utils/toast';
+import { UserRole } from '@/types/auth';
+import { formatDateForDisplay } from '@/utils/dateUtils';
+import { getRoleLabel } from '@/utils/roleUtils';
+
+interface Profile {
+  id: string;
+  email: string;
+  role: UserRole;
+  created_at: string;
+  name?: string | null;
+}
+
+const roles: UserRole[] = ['user', 'cliente', 'suporte', 'admin'];
+
+const AdminConfig = () => {
+  const queryClient = useQueryClient();
+  const [editingUser, setEditingUser] = useState<Profile | null>(null);
+  const [formState, setFormState] = useState({ name: '', email: '', role: 'user' as UserRole });
+
+  const { data: users = [], isLoading } = useQuery({
+    queryKey: ['admin-users'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, email, role, created_at, name')
+        .is('deleted_at', null);
+      if (error) throw error;
+      return data as Profile[];
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (user: Profile) => {
+      const { error } = await supabase
+        .from('profiles')
+        .update({ email: user.email, role: user.role, name: user.name })
+        .eq('id', user.id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Usuário atualizado com sucesso');
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+    },
+    onError: () => toast.error('Falha ao atualizar usuário')
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase
+        .from('profiles')
+        .update({ deleted_at: new Date().toISOString() })
+        .eq('id', id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Usuário excluído');
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+    },
+    onError: () => toast.error('Erro ao excluir usuário')
+  });
+
+  const openEdit = (user: Profile) => {
+    setFormState({ name: user.name || '', email: user.email, role: user.role });
+    setEditingUser(user);
+  };
+
+  const handleSave = () => {
+    if (!editingUser) return;
+    updateMutation.mutate({ ...editingUser, ...formState });
+    setEditingUser(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Configurações de Administrador</h1>
+        <p className="text-muted-foreground">Gerencie contas de usuários</p>
+      </div>
+
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Nome</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Criado em</TableHead>
+              <TableHead>Ações</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map(u => (
+              <TableRow key={u.id}>
+                <TableCell>{u.email}</TableCell>
+                <TableCell>{u.name || '-'}</TableCell>
+                <TableCell>{getRoleLabel(u.role)}</TableCell>
+                <TableCell>{formatDateForDisplay(u.created_at)}</TableCell>
+                <TableCell className="space-x-2">
+                  <Button size="sm" variant="outline" onClick={() => openEdit(u)}>Editar</Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button size="sm" variant="destructive">Excluir</Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Confirmar exclusão</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Tem certeza que deseja excluir este usuário?
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => deleteMutation.mutate(u.id)}>Excluir</AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        {isLoading && <p className="p-4">Carregando usuários...</p>}
+      </div>
+
+      <Dialog open={!!editingUser} onOpenChange={val => !val && setEditingUser(null)}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Editar Usuário</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <Input
+              placeholder="Nome"
+              value={formState.name}
+              onChange={e => setFormState(s => ({ ...s, name: e.target.value }))}
+            />
+            <Input
+              placeholder="Email"
+              value={formState.email}
+              onChange={e => setFormState(s => ({ ...s, email: e.target.value }))}
+            />
+            <Select value={formState.role} onValueChange={v => setFormState(s => ({ ...s, role: v as UserRole }))}>
+              <SelectTrigger>
+                <SelectValue placeholder="Role" />
+              </SelectTrigger>
+              <SelectContent>
+                {roles.map(r => (
+                  <SelectItem key={r} value={r}>{getRoleLabel(r)}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditingUser(null)}>Cancelar</Button>
+            <Button onClick={handleSave} disabled={updateMutation.isLoading}>{updateMutation.isLoading ? 'Salvando...' : 'Salvar'}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default AdminConfig;

--- a/src/pages/Unauthorized.tsx
+++ b/src/pages/Unauthorized.tsx
@@ -1,0 +1,7 @@
+import { InsufficientPermissions } from '@/components/auth/InsufficientPermissions';
+
+const Unauthorized = () => (
+  <InsufficientPermissions requiredRole="admin" />
+);
+
+export default Unauthorized;


### PR DESCRIPTION
## Summary
- add `<PrivateRoute>` component to protect admin-only pages
- build AdminConfig page for user management
- show unauthorized page for restricted access
- register routes for admin config and unauthorized

## Testing
- `npm run lint` *(fails: 228 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68486cefacc88325990a090456405faf