### PR TITLE
Fix isAuthProcessing reset after signIn

### DIFF
--- a/src/hooks/useAuthActions.ts
+++ b/src/hooks/useAuthActions.ts
@@ -369,9 +369,9 @@ export function useAuthActions(updateState: (state: any) => void) {
       updateState({ error: errorMessage, isLoading: false });
       toast.error(errorMessage);
     } finally {
-      if (isAuthProcessing) {
-        setIsAuthProcessing(false);
-      }
+      // Sempre redefinir o estado de processamento de autenticação
+      // para evitar bloqueios em chamadas subsequentes
+      setIsAuthProcessing(false);
     }
   }, [isAuthProcessing, navigate, updateState]);
 


### PR DESCRIPTION
## Summary
- ensure `isAuthProcessing` resets after `signIn`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684873e05bec832591665ffdcd72d21d