### PR TITLE
Add role alias support

### DIFF
--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -32,6 +32,12 @@ export const ROLE_HIERARCHY = {
   usuario: 0
 } as const;
 
+// Mapeamento de sinônimos para os roles
+export const ROLE_SYNONYMS = {
+  suport: 'suporte',
+  support: 'suporte'
+} as const;
+
 // Labels amigáveis para os roles
 export const ROLE_LABELS = {
   admin: 'Administrador',

--- a/src/hooks/useAuthActions.ts
+++ b/src/hooks/useAuthActions.ts
@@ -6,6 +6,7 @@ import { profileService } from '@/services/profileService';
 import { useState, useCallback } from 'react';
 import { UserRole } from '@/types/auth';
 import { DEFAULT_USER_ROLE, AUTH_ERROR_MESSAGES, AuthErrorCategory } from '@/constants/auth';
+import { toUserRole } from '@/utils/roleUtils';
 import { supabase } from '@/integrations/supabase/client';
 
 // Tipo para armazenar informações técnicas de erro para diagnóstico
@@ -61,11 +62,8 @@ export function useAuthActions(updateState: (state: any) => void) {
         role 
       });
       
-      // Ensure we have a valid role
-      if (!['admin', 'suporte', 'cliente', 'usuario'].includes(role)) {
-        console.warn(`Role inválido '${role}' fornecido, usando '${DEFAULT_USER_ROLE}' como padrão`);
-        role = DEFAULT_USER_ROLE as UserRole;
-      }
+      // Garantir que o role seja válido ou mapear sinônimos
+      role = toUserRole(role);
       
       // Melhorado: captura erros da camada de serviço mais detalhadamente
       try {

--- a/src/hooks/useAuthSession.ts
+++ b/src/hooks/useAuthSession.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { profileService } from '@/services/profileService';
 import { toast } from '@/utils/toast';
+import { toUserRole } from '@/utils/roleUtils';
 
 // Debounce function to prevent multiple redirects
 const debounce = (fn: Function, ms = 300) => {
@@ -33,11 +34,8 @@ export function useAuthSession(updateState: (state: any) => void) {
         
         if (profile) {
           console.log('Profile fetched successfully:', profile.email);
-          // Verificar se o role está entre os valores esperados
-          if (!['admin', 'suporte', 'cliente', 'usuario'].includes(profile.role)) {
-            console.warn(`Invalid role detected: ${profile.role}, defaulting to 'cliente'`);
-            profile.role = 'cliente';
-          }
+          // Normalizar role considerando sinônimos
+          profile.role = toUserRole(profile.role);
           
           updateState({ 
             profile,

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -2,6 +2,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { checkPasswordStrength } from '@/utils/passwordStrength';
 import { UserRole } from '@/types/auth';
 import { DEFAULT_USER_ROLE, AuthErrorCategory } from '@/constants/auth';
+import { toUserRole } from '@/utils/roleUtils';
 
 interface SignUpData {
   email: string;
@@ -74,11 +75,8 @@ export const authService = {
   async signUp(email: string, password: string, role: UserRole = DEFAULT_USER_ROLE) {
     console.log('Iniciando processo de cadastro:', { email, role });
     
-    // Ensure role is one of the valid enum values
-    if (!['admin', 'suporte', 'cliente', 'usuario'].includes(role)) {
-      console.warn(`Valor de role inválido: ${role}, usando '${DEFAULT_USER_ROLE}' como padrão`);
-      role = DEFAULT_USER_ROLE as UserRole;
-    }
+    // Converter role para valor reconhecido
+    role = toUserRole(role);
     
     try {
       // Register in Supabase Auth - Using signUp instead of signUpWithPassword for compatibility

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,6 +1,7 @@
 
 import { supabase } from '@/integrations/supabase/client';
 import { UserProfile, UserRole } from '@/types/auth';
+import { toUserRole } from '@/utils/roleUtils';
 
 export const profileService = {
   async fetchUserProfile(userId: string): Promise<UserProfile | null> {
@@ -22,12 +23,8 @@ export const profileService = {
       if (data) {
         console.log('Profile found:', data.email);
         
-        // Validate the role to ensure it's one of the valid values
-        const role = data.role as UserRole;
-        if (!['admin', 'suporte', 'cliente', 'usuario'].includes(role)) {
-          console.warn(`Invalid role found for user ${userId}: ${role}, defaulting to 'cliente'`);
-          data.role = 'cliente';
-        }
+        // Normalizar role para garantir valor reconhecido
+        data.role = toUserRole(data.role as string);
         
         // Map the profiles table fields to the UserProfile type
         return {

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -1,6 +1,12 @@
 
 import { UserRole } from '@/types/auth';
-import { ROLE_HIERARCHY, ROLE_LABELS, ROLE_DESCRIPTIONS, ROLE_COLORS } from '@/constants/auth';
+import {
+  ROLE_HIERARCHY,
+  ROLE_LABELS,
+  ROLE_DESCRIPTIONS,
+  ROLE_COLORS,
+  ROLE_SYNONYMS
+} from '@/constants/auth';
 
 /**
  * Verifica se um role tem permissão mínima necessária
@@ -75,15 +81,18 @@ export const getAssignableRoles = (userRole: UserRole): UserRole[] => {
  * Verifica se um role é válido
  */
 export const isValidRole = (role: string): role is UserRole => {
-  return role in ROLE_HIERARCHY;
+  return role in ROLE_HIERARCHY || role in ROLE_SYNONYMS;
 };
 
 /**
  * Converte string para UserRole com validação
  */
 export const toUserRole = (role: string): UserRole => {
-  if (isValidRole(role)) {
-    return role;
+  if (role in ROLE_HIERARCHY) {
+    return role as UserRole;
+  }
+  if (role in ROLE_SYNONYMS) {
+    return ROLE_SYNONYMS[role as keyof typeof ROLE_SYNONYMS];
   }
   return 'cliente'; // fallback seguro
 };


### PR DESCRIPTION
## Summary
- support `suport`/`support` aliases for the `suporte` role
- convert roles using `toUserRole` across auth flows

## Testing
- `npm run lint` *(fails: 208 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68498ab1d8188325ac2be7e007b6e860