### PR TITLE
Allow soft-deleted profile checks

### DIFF
--- a/src/hooks/useAuthActions.ts
+++ b/src/hooks/useAuthActions.ts
@@ -214,7 +214,8 @@ export function useAuthActions(updateState: (state: any) => void) {
       if (data.user) {
         console.log('Login bem-sucedido para:', email);
         try {
-          let userProfile = await profileService.fetchUserProfile(data.user.id);
+          // Incluir perfis soft-deletados para validação
+          let userProfile = await profileService.fetchUserProfile(data.user.id, true);
           console.log('Perfil obtido após login:', userProfile);
           
           if (!userProfile) {
@@ -240,7 +241,7 @@ export function useAuthActions(updateState: (state: any) => void) {
               };
               console.log('Usando perfil mínimo para continuar o login');
             } else {
-              const profileRetry = await profileService.fetchUserProfile(data.user.id);
+              const profileRetry = await profileService.fetchUserProfile(data.user.id, true);
               if (profileRetry) {
                 userProfile = profileRetry;
               } else {

--- a/src/hooks/useAuthSession.ts
+++ b/src/hooks/useAuthSession.ts
@@ -28,7 +28,8 @@ export function useAuthSession(updateState: (state: any) => void) {
       try {
         if (!isMounted) return;
         
-        const profile = await profileService.fetchUserProfile(userId);
+          // Incluir perfis soft-deletados para validação
+          const profile = await profileService.fetchUserProfile(userId, true);
         
         if (!isMounted) return;
         


### PR DESCRIPTION
## Summary
- add `includeDeleted` option to `fetchUserProfile`
- check for deleted profile records during sign in and session restore

## Testing
- `npm run lint` *(fails: many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1e2966083259edb613e8d92dd70