### PR TITLE
Persist inventory filters

### DIFF
--- a/src/modules/assets/hooks/useInventoryFiltersState.ts
+++ b/src/modules/assets/hooks/useInventoryFiltersState.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+
+export interface InventoryFiltersState {
+  searchTerm: string;
+  filterType: string;
+  filterStatus: string;
+  filterManufacturer: string;
+}
+
+const STORAGE_KEY = 'inventory-filters';
+
+export const useInventoryFiltersState = () => {
+  const [state, setState] = useState<InventoryFiltersState>(() => {
+    if (typeof window === 'undefined') {
+      return {
+        searchTerm: '',
+        filterType: 'all',
+        filterStatus: 'all',
+        filterManufacturer: 'all'
+      };
+    }
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        return {
+          searchTerm: '',
+          filterType: 'all',
+          filterStatus: 'all',
+          filterManufacturer: 'all',
+          ...parsed
+        } as InventoryFiltersState;
+      }
+    } catch (error) {
+      console.warn('Failed to load inventory filters from localStorage:', error);
+    }
+    return {
+      searchTerm: '',
+      filterType: 'all',
+      filterStatus: 'all',
+      filterManufacturer: 'all'
+    };
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn('Failed to save inventory filters to localStorage:', error);
+    }
+  }, [state]);
+
+  const setSearchTerm = (term: string) => {
+    setState(prev => ({ ...prev, searchTerm: term }));
+  };
+
+  const setFilterType = (value: string) => {
+    setState(prev => ({ ...prev, filterType: value }));
+  };
+
+  const setFilterStatus = (value: string) => {
+    setState(prev => ({ ...prev, filterStatus: value }));
+  };
+
+  const setFilterManufacturer = (value: string) => {
+    setState(prev => ({ ...prev, filterManufacturer: value }));
+  };
+
+  const resetFilters = () => {
+    setState({
+      searchTerm: '',
+      filterType: 'all',
+      filterStatus: 'all',
+      filterManufacturer: 'all'
+    });
+  };
+
+  return {
+    searchTerm: state.searchTerm,
+    setSearchTerm,
+    filterType: state.filterType,
+    setFilterType,
+    filterStatus: state.filterStatus,
+    setFilterStatus,
+    filterManufacturer: state.filterManufacturer,
+    setFilterManufacturer,
+    resetFilters
+  };
+};

--- a/src/modules/assets/pages/AssetsInventory.tsx
+++ b/src/modules/assets/pages/AssetsInventory.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useURLFilters } from '@/hooks/useURLFilters';
 import { useAssetsData } from '@modules/assets/hooks/useAssetsData';
+import { useInventoryFiltersState } from '@modules/assets/hooks/useInventoryFiltersState';
 import AssetsHeader from '@modules/assets/components/assets/AssetsHeader';
 import AssetsSearchForm from '@modules/assets/components/assets/AssetsSearchForm';
 import AssetsTable from '@modules/assets/components/assets/AssetsTable';
@@ -13,10 +14,16 @@ import AssetsError from '@modules/assets/components/assets/AssetsError';
 const ASSETS_PER_PAGE = 10;
 
 const AssetsInventory = () => {
-  const [searchTerm, setSearchTerm] = useState("");
-  const [filterType, setFilterType] = useState("all");
-  const [filterStatus, setFilterStatus] = useState("all");
-  const [filterManufacturer, setFilterManufacturer] = useState("all");
+  const {
+    searchTerm,
+    setSearchTerm,
+    filterType,
+    setFilterType,
+    filterStatus,
+    setFilterStatus,
+    filterManufacturer,
+    setFilterManufacturer
+  } = useInventoryFiltersState();
   const [currentPage, setCurrentPage] = useState(1);
   const [shouldFetch, setShouldFetch] = useState(true);
   


### PR DESCRIPTION
## Summary
- persist inventory filters in local storage with `useInventoryFiltersState`
- apply persisted filters in `AssetsInventory`

## Testing
- `npm run lint` *(fails: unexpected any, prefer-const)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b0f24298c8325a9711044a2c61471