### PR TITLE
Fix initial lint errors

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ import { Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-interface FooterProps extends React.HTMLAttributes<HTMLElement> {}
+type FooterProps = React.HTMLAttributes<HTMLElement>
 export function Footer({
   className,
   ...props

--- a/src/components/ui/admin-credentials-fields.tsx
+++ b/src/components/ui/admin-credentials-fields.tsx
@@ -5,11 +5,11 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { PasswordInput } from "@/components/auth/PasswordInput";
 import { Copy } from "lucide-react";
-import { UseFormReturn } from 'react-hook-form';
+import { UseFormReturn, type FieldValues } from 'react-hook-form';
 import { toast } from "@/utils/toast";
 
 interface AdminCredentialsFieldsProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<FieldValues>;
   isLoading: boolean;
   isMobile: boolean;
   title: string;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/network-fields.tsx
+++ b/src/components/ui/network-fields.tsx
@@ -5,11 +5,11 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { PasswordInput } from "@/components/auth/PasswordInput";
 import { Copy, Eye, EyeOff } from "lucide-react";
-import { UseFormReturn } from 'react-hook-form';
+import { UseFormReturn, type FieldValues } from 'react-hook-form';
 import { toast } from "@/utils/toast";
 
 interface NetworkFieldsProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<FieldValues>;
   isLoading: boolean;
   isMobile: boolean;
   fieldPrefix: 'fabrica' | 'atual';

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,7 +1,7 @@
 
 import { cn } from "@/lib/utils";
 
-interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement>
 
 export function Skeleton({ className, ...props }: SkeletonProps) {
   return (

--- a/src/components/ui/standard-status-badge.tsx
+++ b/src/components/ui/standard-status-badge.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { Badge } from "@/components/ui/badge";
+import { Badge, badgeVariants } from "@/components/ui/badge";
+import type { VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 interface StandardStatusBadgeProps {
@@ -54,11 +55,12 @@ export const StandardStatusBadge: React.FC<StandardStatusBadgeProps> = ({
     }
   };
 
-  const variant = getStatusVariant(status, type);
+  const variant: VariantProps<typeof badgeVariants>["variant"] =
+    getStatusVariant(status, type);
 
   return (
-    <Badge 
-      variant={variant as any} 
+    <Badge
+      variant={variant}
       className={cn("text-xs font-neue-haas", className)}
     >
       {status}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- resolve some eslint errors
- update form types
- use type aliases for empty interfaces
- type badge variants

## Testing
- `npm run lint` *(fails: 235 problems)*

------
https://chatgpt.com/codex/tasks/task_e_685b0fd3dae88325b731088b6df299e5