### PR TITLE
Refactor UI utilities

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
 import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button-variants"
 
 const AlertDialog = AlertDialogPrimitive.Root
 

--- a/src/components/ui/badge-variants.ts
+++ b/src/components/ui/badge-variants.ts
@@ -1,0 +1,27 @@
+import { cva } from "class-variance-authority"
+
+export const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-legal-primary text-white hover:bg-legal-primary-light dark:bg-legal-primary dark:hover:bg-legal-primary-light shadow-legal-sm",
+        secondary:
+          "border-transparent bg-legal-secondary/50 text-legal-dark hover:bg-legal-secondary hover:text-bg-primary-dark dark:bg-legal-secondary/50 dark:text-legal-dark dark:hover:bg-legal-secondary shadow-legal-sm",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-legal-sm",
+        outline:
+          "border-legal-primary text-legal-primary bg-transparent hover:bg-legal-primary/10 dark:border-legal-secondary dark:text-legal-secondary dark:hover:bg-legal-secondary/10",
+        success:
+          "border-transparent bg-success text-success-foreground hover:bg-success/90 shadow-legal-sm",
+        warning:
+          "border-transparent bg-warning text-warning-foreground hover:bg-warning/90 shadow-legal-sm",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,33 +1,9 @@
 
 import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-
-const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
-  {
-    variants: {
-      variant: {
-        default: 
-          "border-transparent bg-legal-primary text-white hover:bg-legal-primary-light dark:bg-legal-primary dark:hover:bg-legal-primary-light shadow-legal-sm",
-        secondary:
-          "border-transparent bg-legal-secondary/50 text-legal-dark hover:bg-legal-secondary hover:text-bg-primary-dark dark:bg-legal-secondary/50 dark:text-legal-dark dark:hover:bg-legal-secondary shadow-legal-sm",
-        destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-legal-sm",
-        outline: 
-          "border-legal-primary text-legal-primary bg-transparent hover:bg-legal-primary/10 dark:border-legal-secondary dark:text-legal-secondary dark:hover:bg-legal-secondary/10",
-        success:
-          "border-transparent bg-success text-success-foreground hover:bg-success/90 shadow-legal-sm",
-        warning:
-          "border-transparent bg-warning text-warning-foreground hover:bg-warning/90 shadow-legal-sm",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
+import { badgeVariants } from "./badge-variants"
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -39,4 +15,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,0 +1,34 @@
+import { cva } from "class-variance-authority"
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-legal-primary dark:focus-visible:ring-legal-secondary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-legal-primary text-white hover:bg-legal-primary-light dark:bg-legal-primary dark:hover:bg-legal-primary-light shadow-legal",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-legal",
+        outline:
+          "border border-legal-primary text-legal-primary bg-transparent hover:bg-legal-primary/10 dark:border-legal-secondary dark:text-legal-secondary dark:hover:bg-legal-secondary/10 shadow-legal-sm",
+        secondary:
+          "bg-legal-secondary text-legal-dark hover:bg-legal-secondary-light dark:bg-legal-secondary dark:text-bg-primary-dark dark:hover:bg-legal-secondary-light shadow-legal",
+        ghost:
+          "bg-transparent text-legal-primary hover:bg-legal-primary/10 dark:text-legal-secondary dark:hover:bg-legal-secondary/10",
+        link:
+          "text-legal-primary underline-offset-4 hover:underline hover:text-legal-primary-light dark:text-legal-secondary dark:hover:text-legal-secondary-light",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,41 +1,10 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-legal-primary dark:focus-visible:ring-legal-secondary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-legal-primary text-white hover:bg-legal-primary-light dark:bg-legal-primary dark:hover:bg-legal-primary-light shadow-legal",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-legal",
-        outline:
-          "border border-legal-primary text-legal-primary bg-transparent hover:bg-legal-primary/10 dark:border-legal-secondary dark:text-legal-secondary dark:hover:bg-legal-secondary/10 shadow-legal-sm",
-        secondary:
-          "bg-legal-secondary text-legal-dark hover:bg-legal-secondary-light dark:bg-legal-secondary dark:text-bg-primary-dark dark:hover:bg-legal-secondary-light shadow-legal",
-        ghost:
-          "bg-transparent text-legal-primary hover:bg-legal-primary/10 dark:text-legal-secondary dark:hover:bg-legal-secondary/10",
-        link:
-          "text-legal-primary underline-offset-4 hover:underline hover:text-legal-primary-light dark:text-legal-secondary dark:hover:text-legal-secondary-light",
-      },
-      size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { buttonVariants } from "./button-variants"
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -57,4 +26,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = "Button"
 
-export { Button, buttonVariants }
+export { Button }

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { DayPicker } from "react-day-picker";
 
 import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button-variants";
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -7,24 +7,13 @@ import {
   FieldPath,
   FieldValues,
   FormProvider,
-  useFormContext,
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
+import { useFormField, FormFieldContext, FormItemContext } from "./use-form-field"
 
 const Form = FormProvider
-
-type FormFieldContextValue<
-  TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
-> = {
-  name: TName
-}
-
-const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
-)
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
@@ -38,37 +27,6 @@ const FormField = <
     </FormFieldContext.Provider>
   )
 }
-
-const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext)
-  const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
-
-  const fieldState = getFieldState(fieldContext.name, formState)
-
-  if (!fieldContext) {
-    throw new Error("useFormField should be used within <FormField>")
-  }
-
-  const { id } = itemContext
-
-  return {
-    id,
-    name: fieldContext.name,
-    formItemId: `${id}-form-item`,
-    formDescriptionId: `${id}-form-item-description`,
-    formMessageId: `${id}-form-item-message`,
-    ...fieldState,
-  }
-}
-
-type FormItemContextValue = {
-  id: string
-}
-
-const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
-)
 
 const FormItem = React.forwardRef<
   HTMLDivElement,
@@ -165,7 +123,6 @@ const FormMessage = React.forwardRef<
 FormMessage.displayName = "FormMessage"
 
 export {
-  useFormField,
   Form,
   FormItem,
   FormLabel,

--- a/src/components/ui/legal-theme-provider.tsx
+++ b/src/components/ui/legal-theme-provider.tsx
@@ -1,20 +1,8 @@
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ThemeValidator } from './theme-validator';
+import { LegalThemeContext, type LegalThemeConfig } from './useLegalTheme';
 
-interface LegalThemeConfig {
-  enableAnimations: boolean;
-  enableRippleEffect: boolean;
-  contrastMode: 'normal' | 'high';
-  reducedMotion: boolean;
-}
-
-interface LegalThemeContextType {
-  config: LegalThemeConfig;
-  updateConfig: (newConfig: Partial<LegalThemeConfig>) => void;
-}
-
-const LegalThemeContext = createContext<LegalThemeContextType | undefined>(undefined);
 
 interface LegalThemeProviderProps {
   children: React.ReactNode;
@@ -108,10 +96,3 @@ export const LegalThemeProvider: React.FC<LegalThemeProviderProps> = ({ children
   );
 };
 
-export const useLegalTheme = () => {
-  const context = useContext(LegalThemeContext);
-  if (context === undefined) {
-    throw new Error('useLegalTheme deve ser usado dentro de um LegalThemeProvider');
-  }
-  return context;
-};

--- a/src/components/ui/legal-theme-types.ts
+++ b/src/components/ui/legal-theme-types.ts
@@ -1,0 +1,12 @@
+export interface LegalThemeConfig {
+  enableAnimations: boolean
+  enableRippleEffect: boolean
+  contrastMode: 'normal' | 'high'
+  reducedMotion: boolean
+}
+
+export interface LegalThemeContextType {
+  config: LegalThemeConfig
+  updateConfig: (newConfig: Partial<LegalThemeConfig>) => void
+}
+

--- a/src/components/ui/navigation-menu-trigger-style.ts
+++ b/src/components/ui/navigation-menu-trigger-style.ts
@@ -1,0 +1,6 @@
+import { cva } from "class-variance-authority"
+
+export const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
+)
+

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
-import { cva } from "class-variance-authority"
 import { ChevronDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { navigationMenuTriggerStyle } from "./navigation-menu-trigger-style"
 
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,
@@ -40,9 +40,6 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
 
 const NavigationMenuItem = NavigationMenuPrimitive.Item
 
-const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
-)
 
 const NavigationMenuTrigger = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
@@ -116,7 +113,6 @@ NavigationMenuIndicator.displayName =
   NavigationMenuPrimitive.Indicator.displayName
 
 export {
-  navigationMenuTriggerStyle,
   NavigationMenu,
   NavigationMenuList,
   NavigationMenuItem,

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -2,7 +2,8 @@ import * as React from "react"
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { ButtonProps, buttonVariants } from "@/components/ui/button"
+import { ButtonProps } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button-variants"
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav

--- a/src/components/ui/sidebar-context.tsx
+++ b/src/components/ui/sidebar-context.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+export type SidebarContextValue = {
+  state: 'expanded' | 'collapsed'
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+export const SidebarContext = React.createContext<SidebarContextValue | null>(null)
+
+export function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error('useSidebar must be used within a SidebarProvider.')
+  }
+  return context
+}
+

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { SidebarContext, useSidebar, type SidebarContextValue } from "./sidebar-context"
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -25,26 +26,7 @@ const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
-type SidebarContext = {
-  state: "expanded" | "collapsed"
-  open: boolean
-  setOpen: (open: boolean) => void
-  openMobile: boolean
-  setOpenMobile: (open: boolean) => void
-  isMobile: boolean
-  toggleSidebar: () => void
-}
 
-const SidebarContext = React.createContext<SidebarContext | null>(null)
-
-function useSidebar() {
-  const context = React.useContext(SidebarContext)
-  if (!context) {
-    throw new Error("useSidebar must be used within a SidebarProvider.")
-  }
-
-  return context
-}
 
 const SidebarProvider = React.forwardRef<
   HTMLDivElement,
@@ -115,7 +97,7 @@ const SidebarProvider = React.forwardRef<
     // This makes it easier to style the sidebar with Tailwind classes.
     const state = open ? "expanded" : "collapsed"
 
-    const contextValue = React.useMemo<SidebarContext>(
+    const contextValue = React.useMemo<SidebarContextValue>(
       () => ({
         state,
         open,
@@ -758,5 +740,4 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 }

--- a/src/components/ui/standard-status-badge.tsx
+++ b/src/components/ui/standard-status-badge.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { Badge, badgeVariants } from "@/components/ui/badge";
+import { Badge } from "@/components/ui/badge";
+import { badgeVariants } from "@/components/ui/badge-variants";
 import type { VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/theme-validator.tsx
+++ b/src/components/ui/theme-validator.tsx
@@ -1,6 +1,7 @@
 
 import React, { useEffect } from 'react';
 import { useTheme } from '@/context/ThemeContext';
+import { useAccessibilityValidator } from './useAccessibilityValidator';
 
 interface ThemeValidatorProps {
   children: React.ReactNode;
@@ -73,30 +74,3 @@ export const ThemeValidator: React.FC<ThemeValidatorProps> = ({ children }) => {
   return <>{children}</>;
 };
 
-// Hook para validação de acessibilidade
-export const useAccessibilityValidator = () => {
-  useEffect(() => {
-    // Verificar se elementos interativos têm labels adequados
-    const validateAccessibility = () => {
-      const buttons = document.querySelectorAll('button:not([aria-label]):not([aria-labelledby])');
-      const inputs = document.querySelectorAll('input:not([aria-label]):not([aria-labelledby]):not([id])');
-      
-      if (buttons.length > 0) {
-        console.warn('🔍 A11y: Botões sem labels de acessibilidade encontrados:', buttons.length);
-      }
-      
-      if (inputs.length > 0) {
-        console.warn('🔍 A11y: Inputs sem labels de acessibilidade encontrados:', inputs.length);
-      }
-      
-      // Verificar contraste de foco
-      const focusableElements = document.querySelectorAll('[tabindex], button, input, select, textarea, a[href]');
-      console.log(`🔍 A11y: ${focusableElements.length} elementos focáveis encontrados`);
-    };
-
-    // Executar após um breve delay para permitir renderização
-    const timeoutId = setTimeout(validateAccessibility, 1000);
-    
-    return () => clearTimeout(timeoutId);
-  }, []);
-};

--- a/src/components/ui/toggle-variants.ts
+++ b/src/components/ui/toggle-variants.ts
@@ -1,0 +1,24 @@
+import { cva } from "class-variance-authority"
+
+export const toggleVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-3",
+        sm: "h-9 px-2.5",
+        lg: "h-11 px-5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,30 +1,9 @@
 import * as React from "react"
 import * as TogglePrimitive from "@radix-ui/react-toggle"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-
-const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
-  {
-    variants: {
-      variant: {
-        default: "bg-transparent",
-        outline:
-          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
-      },
-      size: {
-        default: "h-10 px-3",
-        sm: "h-9 px-2.5",
-        lg: "h-11 px-5",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { toggleVariants } from "./toggle-variants"
 
 const Toggle = React.forwardRef<
   React.ElementRef<typeof TogglePrimitive.Root>,
@@ -40,4 +19,4 @@ const Toggle = React.forwardRef<
 
 Toggle.displayName = TogglePrimitive.Root.displayName
 
-export { Toggle, toggleVariants }
+export { Toggle }

--- a/src/components/ui/use-form-field.tsx
+++ b/src/components/ui/use-form-field.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { FieldPath, FieldValues, useFormContext } from 'react-hook-form'
+
+export type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue)
+const FormItemContext = React.createContext<{ id: string }>({} as { id: string })
+
+export const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>')
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+export { FormFieldContext, FormItemContext }
+

--- a/src/components/ui/useAccessibilityValidator.ts
+++ b/src/components/ui/useAccessibilityValidator.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+
+/**
+ * Hook para validação de acessibilidade
+ */
+export const useAccessibilityValidator = () => {
+  useEffect(() => {
+    // Verificar se elementos interativos têm labels adequados
+    const validateAccessibility = () => {
+      const buttons = document.querySelectorAll('button:not([aria-label]):not([aria-labelledby])')
+      const inputs = document.querySelectorAll('input:not([aria-label]):not([aria-labelledby]):not([id])')
+
+      if (buttons.length > 0) {
+        console.warn('🔍 A11y: Botões sem labels de acessibilidade encontrados:', buttons.length)
+      }
+
+      if (inputs.length > 0) {
+        console.warn('🔍 A11y: Inputs sem labels de acessibilidade encontrados:', inputs.length)
+      }
+
+      // Verificar contraste de foco
+      const focusableElements = document.querySelectorAll('[tabindex], button, input, select, textarea, a[href]')
+      console.log(`🔍 A11y: ${focusableElements.length} elementos focáveis encontrados`)
+    }
+
+    // Executar após um breve delay para permitir renderização
+    const timeoutId = setTimeout(validateAccessibility, 1000)
+
+    return () => clearTimeout(timeoutId)
+  }, [])
+}
+

--- a/src/components/ui/useLegalTheme.ts
+++ b/src/components/ui/useLegalTheme.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+import type { LegalThemeConfig, LegalThemeContextType } from './legal-theme-types'
+
+export const LegalThemeContext = createContext<LegalThemeContextType | undefined>(undefined)
+
+export const useLegalTheme = () => {
+  const context = useContext(LegalThemeContext)
+  if (context === undefined) {
+    throw new Error('useLegalTheme deve ser usado dentro de um LegalThemeProvider')
+  }
+  return context
+}
+
+export type { LegalThemeConfig, LegalThemeContextType }
+


### PR DESCRIPTION
## Summary
- split variant helpers like `badgeVariants` and `buttonVariants` into standalone files
- move `useFormField`, `useAccessibilityValidator`, and theme helpers out of their component files
- extract navigation menu style and sidebar context to separate modules
- update component imports accordingly

## Testing
- `npm run lint` *(fails: 242 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685be3db82688325884ecaddbc9d4ef7