### PR TITLE
Fix exhaustive deps warnings

### DIFF
--- a/src/modules/assets/pages/AssetsInventory.tsx
+++ b/src/modules/assets/pages/AssetsInventory.tsx
@@ -71,7 +71,7 @@ const AssetsInventory = () => {
     setSearchTerm(value);
     setCurrentPage(1);
     setShouldFetch(true);
-  }, []);
+  }, [setSearchTerm]);
   
   const handleFilterChange = useCallback((type: string, value: string) => {
     console.log(`Filtro ${type} alterado para:`, value);
@@ -91,7 +91,7 @@ const AssetsInventory = () => {
     updateURLParams({
       [type]: value
     });
-  }, [updateURLParams]);
+  }, [setFilterType, setFilterStatus, setFilterManufacturer, updateURLParams]);
 
   const handleAssetUpdated = useCallback(() => {
     console.log('Asset atualizado, invalidando cache e recarregando dados...');

--- a/src/modules/assets/pages/assets/register/useRegisterAsset.ts
+++ b/src/modules/assets/pages/assets/register/useRegisterAsset.ts
@@ -45,7 +45,7 @@ export function useRegisterAsset() {
       console.log('[useRegisterAsset] Resetting mutation state due to asset type change');
       formHandlers.createAssetMutation.reset();
     }
-  }, [assetType]);
+  }, [assetType, formHandlers.createAssetMutation]);
 
   // Sync form data with state management
   useEffect(() => {
@@ -54,17 +54,17 @@ export function useRegisterAsset() {
     } else {
       syncWithForm(equipmentForm, "equipment");
     }
-  }, [assetType]);
+  }, [assetType, chipForm, equipmentForm, syncWithForm]);
 
   useEffect(() => {
     const sub = chipForm.watch(data => updateFormData(data, "chip"));
     return () => sub.unsubscribe();
-  }, [chipForm.watch, updateFormData]);
+  }, [chipForm, chipForm.watch, updateFormData]);
 
   useEffect(() => {
     const sub = equipmentForm.watch(data => updateFormData(data, "equipment"));
     return () => sub.unsubscribe();
-  }, [equipmentForm.watch, updateFormData]);
+  }, [equipmentForm, equipmentForm.watch, updateFormData]);
 
   // Update success state when mutation succeeds
   useEffect(() => {
@@ -79,7 +79,12 @@ export function useRegisterAsset() {
       console.log('[useRegisterAsset] Setting showSuccess to true for asset type:', assetType);
       setShowSuccess(true);
     }
-  }, [formHandlers.createAssetMutation.isSuccess, assetType]);
+  }, [
+    formHandlers.createAssetMutation.isSuccess,
+    formHandlers.createAssetMutation.isError,
+    formHandlers.createAssetMutation.isPending,
+    assetType
+  ]);
 
   // Reset success state when starting a new submission
   useEffect(() => {


### PR DESCRIPTION
## Summary
- include all state setters in callback dependencies
- add missing dependencies in register asset hook

## Testing
- `npm run lint` *(fails: 258 problems (242 errors, 16 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_685be7e27fbc8325bacb33159d4c9cac