### PR TITLE
Replace short-circuit debug logs

### DIFF
--- a/src/modules/associations/components/associations/AddAssetsDialog.tsx
+++ b/src/modules/associations/components/associations/AddAssetsDialog.tsx
@@ -36,37 +36,49 @@ export const AddAssetsDialog: React.FC<AddAssetsDialogProps> = ({
   const addAssetsMutation = useAddAssetsToAssociation();
 
   const handleAssetSelected = (asset: SelectedAsset) => {
-    process.env.NODE_ENV === 'development' &&
+    if (process.env.NODE_ENV === 'development') {
       console.log('AddAssetsDialog: Tentando adicionar asset', asset.uuid);
+    }
     
     // Verificar se o asset já foi selecionado (evitar duplicatas)
     const isAlreadySelected = selectedAssets.some(selectedAsset => selectedAsset.uuid === asset.uuid);
     
     if (isAlreadySelected) {
-      process.env.NODE_ENV === 'development' &&
+      if (process.env.NODE_ENV === 'development') {
         console.log('AddAssetsDialog: Asset já selecionado', asset.uuid);
+      }
       toast.warning('Este ativo já foi selecionado');
       return;
     }
 
-    process.env.NODE_ENV === 'development' &&
+    if (process.env.NODE_ENV === 'development') {
       console.log('AddAssetsDialog: Adicionando novo asset', asset.uuid);
+    }
     setSelectedAssets(prev => {
       const newList = [...prev, asset];
-      process.env.NODE_ENV === 'development' &&
-        console.log('AddAssetsDialog: Nova lista de assets selecionados', newList.map(a => a.uuid));
+      if (process.env.NODE_ENV === 'development') {
+        console.log(
+          'AddAssetsDialog: Nova lista de assets selecionados',
+          newList.map(a => a.uuid)
+        );
+      }
       return newList;
     });
     toast.success('Ativo adicionado à seleção');
   };
 
   const handleAssetRemoved = (assetId: string) => {
-    process.env.NODE_ENV === 'development' &&
+    if (process.env.NODE_ENV === 'development') {
       console.log('AddAssetsDialog: Removendo asset', assetId);
+    }
     setSelectedAssets(prev => {
       const newList = prev.filter(asset => asset.uuid !== assetId);
-      process.env.NODE_ENV === 'development' &&
-        console.log('AddAssetsDialog: Nova lista após remoção', newList.map(a => a.uuid));
+      if (process.env.NODE_ENV === 'development') {
+        console.log(
+          'AddAssetsDialog: Nova lista após remoção',
+          newList.map(a => a.uuid)
+        );
+      }
       return newList;
     });
   };
@@ -81,8 +93,12 @@ export const AddAssetsDialog: React.FC<AddAssetsDialogProps> = ({
 
   const handleConfirm = async () => {
     try {
-      process.env.NODE_ENV === 'development' &&
-        console.log('AddAssetsDialog: Iniciando adição de assets', selectedAssets.map(a => a.uuid));
+      if (process.env.NODE_ENV === 'development') {
+        console.log(
+          'AddAssetsDialog: Iniciando adição de assets',
+          selectedAssets.map(a => a.uuid)
+        );
+      }
       
       const result = await addAssetsMutation.mutateAsync({
         client_id: existingAssociation.client_id,
@@ -96,8 +112,9 @@ export const AddAssetsDialog: React.FC<AddAssetsDialogProps> = ({
         gb: existingAssociation.gb
       });
 
-      process.env.NODE_ENV === 'development' &&
+      if (process.env.NODE_ENV === 'development') {
         console.log('AddAssetsDialog: Resultado da adição:', result);
+      }
 
       // Lógica de fechamento do modal mais rigorosa
       if (result.success) {

--- a/src/modules/associations/services/addAssetsService.ts
+++ b/src/modules/associations/services/addAssetsService.ts
@@ -32,8 +32,9 @@ export interface AddAssetsToAssociationResult {
 export const addAssetsToAssociation = async (
   params: AddAssetsToAssociationParams
 ): Promise<AddAssetsToAssociationResult> => {
-  process.env.NODE_ENV === 'development' &&
+  if (process.env.NODE_ENV === 'development') {
     console.log('Chamando add_assets_to_association com parâmetros:', params);
+  }
 
   const { data, error } = await supabase.rpc('add_assets_to_association', {
     p_client_id: params.client_id,
@@ -52,7 +53,8 @@ export const addAssetsToAssociation = async (
     throw error;
   }
 
-  process.env.NODE_ENV === 'development' &&
+  if (process.env.NODE_ENV === 'development') {
     console.log('Resultado da adição de ativos:', data);
+  }
   return data as unknown as AddAssetsToAssociationResult;
 };

--- a/src/modules/dashboard/components/dashboard/QuickActionsCard.tsx
+++ b/src/modules/dashboard/components/dashboard/QuickActionsCard.tsx
@@ -19,7 +19,9 @@ export const QuickActionsCard: React.FC = () => {
   const { canCreateAssets, canManageAssociations, canExportData } = usePermissions();
 
   const handleImportCSV = () => {
-    process.env.NODE_ENV === 'development' && console.log("IMPORT CSV");
+    if (process.env.NODE_ENV === 'development') {
+      console.log('IMPORT CSV');
+    }
   };
 
   const handleExport = (format: 'csv' | 'excel') => {
@@ -78,7 +80,9 @@ export const QuickActionsCard: React.FC = () => {
         XLSX.writeFile(wb, `${fileName}.xlsx`);
       }
     } catch (error) {
-      process.env.NODE_ENV === 'development' && console.log(`ERRO DE EXPORTAÇÃO:===>>>> ${error}`);
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`ERRO DE EXPORTAÇÃO:===>>>> ${error}`);
+      }
     }
   };
 

--- a/src/modules/dashboard/hooks/useDashboardAssociations.ts
+++ b/src/modules/dashboard/hooks/useDashboardAssociations.ts
@@ -22,7 +22,9 @@ export function useDashboardAssociations() {
     queryKey: ['dashboard', 'associations'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('Fetching dashboard associations data...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Fetching dashboard associations data...');
+        }
         
         const [
           activeAssociationsResult,

--- a/src/modules/dashboard/hooks/useDashboardAssociationsDetailed.ts
+++ b/src/modules/dashboard/hooks/useDashboardAssociationsDetailed.ts
@@ -52,7 +52,9 @@ export function useDashboardAssociationsDetailed() {
     queryKey: ['dashboard', 'associations-detailed-optimized'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('Fetching detailed associations data (optimized - single query)...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Fetching detailed associations data (optimized - single query)...');
+        }
         
         const activeAssociationsResult = await dashboardQueries.fetchActiveAssociations();
         
@@ -113,8 +115,10 @@ export function useDashboardAssociationsDetailed() {
           };
         };
         
-        process.env.NODE_ENV === 'development' && console.log(`Processando ${associations.length} associações ativas sem queries adicionais`);
-        process.env.NODE_ENV === 'development' && console.log(`Locações: ${rentalAssociations.length}, Assinaturas: ${subscriptionAssociations.length}`);
+        if (process.env.NODE_ENV === 'development') {
+          console.log(`Processando ${associations.length} associações ativas sem queries adicionais`);
+          console.log(`Locações: ${rentalAssociations.length}, Assinaturas: ${subscriptionAssociations.length}`);
+        }
         
         return {
           rental: processAssociationsOptimized(rentalAssociations),

--- a/src/modules/dashboard/hooks/useDashboardCards.ts
+++ b/src/modules/dashboard/hooks/useDashboardCards.ts
@@ -49,7 +49,9 @@ export const useDashboardCards = () => {
       try {
         // Use the API service to fetch problem assets
         const assets = await assetService.listProblemAssets();
-        process.env.NODE_ENV === 'development' && console.log("Raw problem assets data:", assets);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Raw problem assets data:', assets);
+        }
         
         // Get status names for mapping
         const { data: statuses } = await supabase
@@ -72,7 +74,9 @@ export const useDashboardCards = () => {
           };
         });
         
-        process.env.NODE_ENV === 'development' && console.log("Transformed problem assets:", items);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Transformed problem assets:', items);
+        }
         return {
           count: items.length,
           items: items.slice(0, 5) // Keep slice only for display items, not count
@@ -90,7 +94,9 @@ export const useDashboardCards = () => {
     queryFn: async () => {
       try {
         const assets = await assetService.getAssetsByStatus(2);
-        process.env.NODE_ENV === 'development' && console.log("Raw on-lease assets:", assets);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Raw on-lease assets:', assets);
+        }
 
         const items = assets.map((asset) => {
           const normalized = normalizeAsset(asset);
@@ -102,7 +108,9 @@ export const useDashboardCards = () => {
           };
         });
         
-        process.env.NODE_ENV === 'development' && console.log("Transformed on-lease assets:", items);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Transformed on-lease assets:', items);
+        }
         return {
           count: items.length, // Full count for statistics
           items: items.slice(0, 5) // Slice only for display items
@@ -120,7 +128,9 @@ export const useDashboardCards = () => {
     queryFn: async () => {
       try {
         const assets = await assetService.getAssetsByStatus(3);
-        process.env.NODE_ENV === 'development' && console.log("Raw subscription assets:", assets);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Raw subscription assets:', assets);
+        }
 
         const items = assets.map((asset) => {
           const normalized = normalizeAsset(asset);
@@ -132,7 +142,9 @@ export const useDashboardCards = () => {
           };
         });
         
-        process.env.NODE_ENV === 'development' && console.log("Transformed subscription assets:", items);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Transformed subscription assets:', items);
+        }
         return {
           count: items.length, // Full count for statistics
           items: items.slice(0, 5) // Slice only for display items
@@ -207,11 +219,13 @@ export const useDashboardCards = () => {
         // Equipamentos: tudo que não é chip nem speedy
         const equipment = (assets || []).filter(a => a.solution_id !== 11 && a.solution_id !== 1);
         
-        process.env.NODE_ENV === 'development' && console.log('Assets categorization debug:');
-        process.env.NODE_ENV === 'development' && console.log('Total assets:', assets?.length);
-        process.env.NODE_ENV === 'development' && console.log('Chips (solution_id=11):', chips.length);
-        process.env.NODE_ENV === 'development' && console.log('Speedys (solution_id=1):', speedy.length);
-        process.env.NODE_ENV === 'development' && console.log('Equipment (outros):', equipment.length);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Assets categorization debug:');
+          console.log('Total assets:', assets?.length);
+          console.log('Chips (solution_id=11):', chips.length);
+          console.log('Speedys (solution_id=1):', speedy.length);
+          console.log('Equipment (outros):', equipment.length);
+        }
         
         // Count available and unavailable assets
         const availableChips = chips.filter(a => a.status_id === availableStatusId);
@@ -251,7 +265,9 @@ export const useDashboardCards = () => {
           }
         };
         
-        process.env.NODE_ENV === 'development' && console.log('Final stats result:', result);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Final stats result:', result);
+        }
         return result;
       } catch (error) {
         console.error("Error fetching assets statistics:", error);

--- a/src/modules/dashboard/hooks/useDashboardCharts.ts
+++ b/src/modules/dashboard/hooks/useDashboardCharts.ts
@@ -21,7 +21,9 @@ export function useDashboardCharts() {
     queryKey: ['dashboard', 'charts'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('Fetching dashboard charts data...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Fetching dashboard charts data...');
+        }
         
         const [
           statusSummaryResult,

--- a/src/modules/dashboard/hooks/useDashboardRecentActivities.ts
+++ b/src/modules/dashboard/hooks/useDashboardRecentActivities.ts
@@ -18,7 +18,9 @@ export function useDashboardRecentActivities() {
     queryKey: ['dashboard', 'recent-activities'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('Fetching recent activities...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Fetching recent activities...');
+        }
         
         const recentEventsResult = await dashboardQueries.fetchEnhancedRecentEvents();
         

--- a/src/modules/dashboard/hooks/useDashboardStats.ts
+++ b/src/modules/dashboard/hooks/useDashboardStats.ts
@@ -45,7 +45,9 @@ export function useDashboardStats() {
     queryKey: ['dashboard', 'stats'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('Fetching dashboard stats...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Fetching dashboard stats...');
+        }
         
         // Parallel queries for better performance
         const [
@@ -67,13 +69,15 @@ export function useDashboardStats() {
         ]);
 
         // Log query results for debugging
-        process.env.NODE_ENV === 'development' && console.log('Total assets result:', totalAssetsResult);
-        process.env.NODE_ENV === 'development' && console.log('Active clients result:', activeClientsResult);
-        process.env.NODE_ENV === 'development' && console.log('Assets with issues result:', assetsWithIssuesResult);
-        process.env.NODE_ENV === 'development' && console.log('Recent assets result:', recentAssetsResult);
-        process.env.NODE_ENV === 'development' && console.log('Recent events result:', recentEventsResult);
-        process.env.NODE_ENV === 'development' && console.log('Status summary result:', statusSummaryResult);
-        process.env.NODE_ENV === 'development' && console.log('Detailed breakdown result:', detailedBreakdownResult);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Total assets result:', totalAssetsResult);
+          console.log('Active clients result:', activeClientsResult);
+          console.log('Assets with issues result:', assetsWithIssuesResult);
+          console.log('Recent assets result:', recentAssetsResult);
+          console.log('Recent events result:', recentEventsResult);
+          console.log('Status summary result:', statusSummaryResult);
+          console.log('Detailed breakdown result:', detailedBreakdownResult);
+        }
 
         // Error handling for individual queries
         if (totalAssetsResult.error) throw new Error(`Total assets query error: ${totalAssetsResult.error.message}`);
@@ -88,8 +92,10 @@ export function useDashboardStats() {
         const solutionsResult = await dashboardQueries.fetchSolutions();
         const statusResult = await dashboardQueries.fetchStatuses();
         
-        process.env.NODE_ENV === 'development' && console.log('Solutions result:', solutionsResult);
-        process.env.NODE_ENV === 'development' && console.log('Status result:', statusResult);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Solutions result:', solutionsResult);
+          console.log('Status result:', statusResult);
+        }
         
         if (solutionsResult.error) throw new Error(`Solutions query error: ${solutionsResult.error.message}`);
         if (statusResult.error) throw new Error(`Status query error: ${statusResult.error.message}`);

--- a/src/modules/dashboard/hooks/useDashboardStatusByType.ts
+++ b/src/modules/dashboard/hooks/useDashboardStatusByType.ts
@@ -25,7 +25,9 @@ export function useDashboardStatusByType() {
     queryKey: ['dashboard', 'status-by-type'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('Fetching status by type data...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Fetching status by type data...');
+        }
         
         // Use the detailed breakdown query that includes both asset_solutions and asset_status
         const detailedBreakdownResult = await dashboardQueries.fetchDetailedStatusBreakdown();

--- a/src/modules/dashboard/hooks/useDashboardSystemStatus.ts
+++ b/src/modules/dashboard/hooks/useDashboardSystemStatus.ts
@@ -13,7 +13,9 @@ export function useDashboardSystemStatus() {
     queryKey: ['dashboard', 'system-status'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('Fetching system status...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('Fetching system status...');
+        }
         
         // Buscar último evento para determinar última atividade
         const recentEventsResult = await dashboardQueries.fetchRecentEvents();

--- a/src/modules/dashboard/hooks/useLeaseAssets.ts
+++ b/src/modules/dashboard/hooks/useLeaseAssets.ts
@@ -14,7 +14,9 @@ export const useLeaseAssets = () => {
     queryKey: ['dashboard', 'lease-assets'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('🔍 Fetching lease assets data...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('🔍 Fetching lease assets data...');
+        }
         
         // Query para buscar ativos atualmente em locação (association_id = 1)
         // Usando asset_client_assoc para identificar ativos associados
@@ -38,7 +40,9 @@ export const useLeaseAssets = () => {
           throw new Error(`Failed to fetch lease assets: ${error.message}`);
         }
 
-        process.env.NODE_ENV === 'development' && console.log('📊 Raw lease associations data:', leaseAssociations);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('📊 Raw lease associations data:', leaseAssociations);
+        }
 
         // Contar por tipo de solução
         const counts = {
@@ -61,7 +65,9 @@ export const useLeaseAssets = () => {
           counts.total++;
         });
 
-        process.env.NODE_ENV === 'development' && console.log('📈 Lease assets summary:', counts);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('📈 Lease assets summary:', counts);
+        }
         return counts;
         
       } catch (error) {

--- a/src/modules/dashboard/hooks/useRentedAssets.ts
+++ b/src/modules/dashboard/hooks/useRentedAssets.ts
@@ -22,7 +22,9 @@ export const useRentedAssets = () => {
   return useQuery({
     queryKey: ['rented-assets'],
     queryFn: async () => {
-      process.env.NODE_ENV === 'development' && console.log('Fetching rented assets...');
+      if (process.env.NODE_ENV === 'development') {
+        console.log('Fetching rented assets...');
+      }
       
       const { data, error } = await supabase
         .from('assets')
@@ -45,7 +47,9 @@ export const useRentedAssets = () => {
         throw error;
       }
 
-      process.env.NODE_ENV === 'development' && console.log('Rented assets fetched:', data?.length);
+      if (process.env.NODE_ENV === 'development') {
+        console.log('Rented assets fetched:', data?.length);
+      }
       return data as RentedAsset[] || [];
     },
     staleTime: 30 * 1000, // 30 seconds

--- a/src/modules/dashboard/hooks/useSubscriptionAssets.ts
+++ b/src/modules/dashboard/hooks/useSubscriptionAssets.ts
@@ -14,7 +14,9 @@ export const useSubscriptionAssets = () => {
     queryKey: ['dashboard', 'subscription-assets'],
     queryFn: async () => {
       try {
-        process.env.NODE_ENV === 'development' && console.log('🔍 Fetching subscription assets data...');
+        if (process.env.NODE_ENV === 'development') {
+          console.log('🔍 Fetching subscription assets data...');
+        }
         
         // Query para buscar ativos atualmente em assinatura (association_id = 2)
         // Usando asset_client_assoc para identificar ativos associados
@@ -38,7 +40,9 @@ export const useSubscriptionAssets = () => {
           throw new Error(`Failed to fetch subscription assets: ${error.message}`);
         }
 
-        process.env.NODE_ENV === 'development' && console.log('📊 Raw subscription associations data:', subscriptionAssociations);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('📊 Raw subscription associations data:', subscriptionAssociations);
+        }
 
         // Contar por tipo de solução
         const counts = {
@@ -61,7 +65,9 @@ export const useSubscriptionAssets = () => {
           counts.total++;
         });
 
-        process.env.NODE_ENV === 'development' && console.log('📈 Subscription assets summary:', counts);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('📈 Subscription assets summary:', counts);
+        }
         return counts;
         
       } catch (error) {

--- a/src/modules/dashboard/services/dashboardQueries.ts
+++ b/src/modules/dashboard/services/dashboardQueries.ts
@@ -2,41 +2,55 @@ import { supabase } from '@/integrations/supabase/client';
 
 // Fetch total assets count
 export async function fetchTotalAssets() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchTotalAssets query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchTotalAssets query');
+  }
   const result = await supabase
     .from('assets')
     .select('*', { count: 'exact', head: true })
     .is('deleted_at', null);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchTotalAssets result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchTotalAssets result:', result);
+  }
   return result;
 }
 
 // Fetch active clients count
 export async function fetchActiveClients() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchActiveClients query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchActiveClients query');
+  }
   const result = await supabase
     .from('v_active_clients')
     .select('*', { count: 'exact', head: true });
   
-  process.env.NODE_ENV === 'development' && console.log('fetchActiveClients result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchActiveClients result:', result);
+  }
   return result;
 }
 
 // Fetch assets with issues count
 export async function fetchAssetsWithIssues() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchAssetsWithIssues query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchAssetsWithIssues query');
+  }
   const result = await supabase
     .from('v_problem_assets')
     .select('*', { count: 'exact', head: true });
   
-  process.env.NODE_ENV === 'development' && console.log('fetchAssetsWithIssues result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchAssetsWithIssues result:', result);
+  }
   return result;
 }
 
 // Fetch recent assets
 export async function fetchRecentAssets() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchRecentAssets query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchRecentAssets query');
+  }
   const result = await supabase
     .from('assets')
     .select(`
@@ -46,58 +60,78 @@ export async function fetchRecentAssets() {
     .order('created_at', { ascending: false })
     .limit(5);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchRecentAssets result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchRecentAssets result:', result);
+  }
   return result;
 }
 
 // Fetch recent events
 export async function fetchRecentEvents() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchRecentEvents query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchRecentEvents query');
+  }
   const result = await supabase
     .from('asset_logs')
     .select('id, event, date, details')
     .order('date', { ascending: false })
     .limit(5);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchRecentEvents result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchRecentEvents result:', result);
+  }
   return result;
 }
 
 // Fetch status breakdown
 export async function fetchStatusBreakdown() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchStatusBreakdown query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchStatusBreakdown query');
+  }
   const result = await supabase
     .rpc('status_by_asset_type');
   
-  process.env.NODE_ENV === 'development' && console.log('fetchStatusBreakdown result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchStatusBreakdown result:', result);
+  }
   return result;
 }
 
 // Fetch solutions data
 export async function fetchSolutions() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchSolutions query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchSolutions query');
+  }
   const result = await supabase
     .from('asset_solutions')
     .select('id, solution');
   
-  process.env.NODE_ENV === 'development' && console.log('fetchSolutions result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchSolutions result:', result);
+  }
   return result;
 }
 
 // Fetch status data
 export async function fetchStatuses() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchStatuses query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchStatuses query');
+  }
   const result = await supabase
     .from('asset_status')
     .select('id, status');
   
-  process.env.NODE_ENV === 'development' && console.log('fetchStatuses result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchStatuses result:', result);
+  }
   return result;
 }
 
 // NEW: Fetch aggregated data by status only (for PieChart)
 export async function fetchStatusSummary() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchStatusSummary query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchStatusSummary query');
+  }
   const result = await supabase
     .from('assets')
     .select(`
@@ -106,13 +140,17 @@ export async function fetchStatusSummary() {
     `)
     .is('deleted_at', null);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchStatusSummary result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchStatusSummary result:', result);
+  }
   return result;
 }
 
 // NEW: Fetch detailed breakdown by type and status (for tooltip)
 export async function fetchDetailedStatusBreakdown() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchDetailedStatusBreakdown query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchDetailedStatusBreakdown query');
+  }
   const result = await supabase
     .from('assets')
     .select(`
@@ -123,13 +161,17 @@ export async function fetchDetailedStatusBreakdown() {
     `)
     .is('deleted_at', null);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchDetailedStatusBreakdown result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchDetailedStatusBreakdown result:', result);
+  }
   return result;
 }
 
 // NEW: Fetch active associations - OTIMIZADO para evitar N+1 queries
 export async function fetchActiveAssociations() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchActiveAssociations query (optimized)');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchActiveAssociations query (optimized)');
+  }
   const result = await supabase
     .from('asset_client_assoc')
     .select(`
@@ -156,13 +198,17 @@ export async function fetchActiveAssociations() {
     .is('exit_date', null)
     .is('deleted_at', null);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchActiveAssociations result (optimized):', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchActiveAssociations result (optimized):', result);
+  }
   return result;
 }
 
 // NEW: Fetch associations ending today
 export async function fetchAssociationsEndingToday() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchAssociationsEndingToday query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchAssociationsEndingToday query');
+  }
   const today = new Date().toISOString().split('T')[0];
   const result = await supabase
     .from('asset_client_assoc')
@@ -179,13 +225,17 @@ export async function fetchAssociationsEndingToday() {
     .eq('exit_date', today)
     .is('deleted_at', null);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchAssociationsEndingToday result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchAssociationsEndingToday result:', result);
+  }
   return result;
 }
 
 // NEW: Fetch top clients with associations
 export async function fetchTopClientsWithAssociations() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchTopClientsWithAssociations query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchTopClientsWithAssociations query');
+  }
   const result = await supabase
     .from('asset_client_assoc')
     .select(`
@@ -195,13 +245,17 @@ export async function fetchTopClientsWithAssociations() {
     .is('exit_date', null)
     .is('deleted_at', null);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchTopClientsWithAssociations result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchTopClientsWithAssociations result:', result);
+  }
   return result;
 }
 
 // NEW: Fetch associations from last 30 days
 export async function fetchAssociationsLast30Days() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchAssociationsLast30Days query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchAssociationsLast30Days query');
+  }
   const thirtyDaysAgo = new Date();
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   
@@ -218,13 +272,17 @@ export async function fetchAssociationsLast30Days() {
     .gte('created_at', thirtyDaysAgo.toISOString())
     .is('deleted_at', null);
   
-  process.env.NODE_ENV === 'development' && console.log('fetchAssociationsLast30Days result:', result);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchAssociationsLast30Days result:', result);
+  }
   return result;
 }
 
 // NEW: Enhanced recent events with user information
 export async function fetchEnhancedRecentEvents() {
-  process.env.NODE_ENV === 'development' && console.log('Executing fetchEnhancedRecentEvents query');
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Executing fetchEnhancedRecentEvents query');
+  }
   
   // First get the events
   const eventsResult = await supabase
@@ -235,7 +293,9 @@ export async function fetchEnhancedRecentEvents() {
     .limit(10);
   
   if (eventsResult.error) {
-    process.env.NODE_ENV === 'development' && console.log('fetchEnhancedRecentEvents error:', eventsResult.error);
+    if (process.env.NODE_ENV === 'development') {
+      console.log('fetchEnhancedRecentEvents error:', eventsResult.error);
+    }
     return eventsResult;
   }
 
@@ -276,6 +336,8 @@ export async function fetchEnhancedRecentEvents() {
     })()
   }));
 
-  process.env.NODE_ENV === 'development' && console.log('fetchEnhancedRecentEvents enriched result:', { ...eventsResult, data: enrichedData });
+  if (process.env.NODE_ENV === 'development') {
+    console.log('fetchEnhancedRecentEvents enriched result:', { ...eventsResult, data: enrichedData });
+  }
   return { ...eventsResult, data: enrichedData };
 }


### PR DESCRIPTION
## Summary
- convert `process.env.NODE_ENV` short-circuit logs to regular `if` blocks across dashboard and association modules
- keep existing lint rules

## Testing
- `npm run lint` *(fails: unexpected any, no-case-declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685be7e3dab083259e3e3a8d73fc27e0