### PR TITLE
Remove redundant try/catch in association hooks

### DIFF
--- a/src/modules/associations/hooks/useAssociationActions.ts
+++ b/src/modules/associations/hooks/useAssociationActions.ts
@@ -32,38 +32,34 @@ export const useAssociationActions = () => {
           const availableStatusId = statusData.id;
 
           // Usar transação manual sem RPC functions
-          try {
-            // Encerrar associação (definir exit_date)
-            const { data: assocData, error: assocError } = await supabase
-              .from('asset_client_assoc')
-              .update({ 
-                exit_date: new Date().toISOString().split('T')[0] // Data atual
-              })
-              .eq('id', associationId)
-              .eq('asset_id', assetId)
-              .is('exit_date', null) // Só atualizar se ainda não tem exit_date
-              .select()
-              .single();
+          // Encerrar associação (definir exit_date)
+          const { data: assocData, error: assocError } = await supabase
+            .from('asset_client_assoc')
+            .update({
+              exit_date: new Date().toISOString().split('T')[0] // Data atual
+            })
+            .eq('id', associationId)
+            .eq('asset_id', assetId)
+            .is('exit_date', null) // Só atualizar se ainda não tem exit_date
+            .select()
+            .single();
 
-            if (assocError) throw assocError;
+          if (assocError) throw assocError;
 
-            // Verificar se a associação realmente foi atualizada
-            if (!assocData) {
-              throw new Error('Associação não encontrada ou já foi encerrada');
-            }
-
-            // Atualizar status do ativo para DISPONÍVEL
-            const { error: assetError } = await supabase
-              .from('assets')
-              .update({ status_id: availableStatusId })
-              .eq('uuid', assetId);
-
-            if (assetError) throw assetError;
-
-            return assocData;
-          } catch (txError) {
-            throw txError;
+          // Verificar se a associação realmente foi atualizada
+          if (!assocData) {
+            throw new Error('Associação não encontrada ou já foi encerrada');
           }
+
+          // Atualizar status do ativo para DISPONÍVEL
+          const { error: assetError } = await supabase
+            .from('assets')
+            .update({ status_id: availableStatusId })
+            .eq('uuid', assetId);
+
+          if (assetError) throw assetError;
+
+          return assocData;
         },
         associationId,
         'END_ASSOCIATION'

--- a/src/modules/associations/hooks/useCreateAssociation.ts
+++ b/src/modules/associations/hooks/useCreateAssociation.ts
@@ -48,34 +48,30 @@ export const useCreateAssociation = () => {
             mapped_status_id: statusId
           });
 
-          try {
-            // Atualizar status do ativo
-            const { error: assetError } = await supabase
-              .from('assets')
-              .update({ status_id: statusId })
-              .eq('uuid', params.assetId);
+          // Atualizar status do ativo
+          const { error: assetError } = await supabase
+            .from('assets')
+            .update({ status_id: statusId })
+            .eq('uuid', params.assetId);
 
-            if (assetError) throw assetError;
+          if (assetError) throw assetError;
 
-            // Criar associação
-            const { data: assocData, error: assocError } = await supabase
-              .from('asset_client_assoc')
-              .insert({
-                asset_id: params.assetId,
-                client_id: params.clientId,
-                association_id: associationId,
-                entry_date: params.startDate,
-                notes: params.notes
-              })
-              .select()
-              .single();
+          // Criar associação
+          const { data: assocData, error: assocError } = await supabase
+            .from('asset_client_assoc')
+            .insert({
+              asset_id: params.assetId,
+              client_id: params.clientId,
+              association_id: associationId,
+              entry_date: params.startDate,
+              notes: params.notes
+            })
+            .select()
+            .single();
 
-            if (assocError) throw assocError;
+          if (assocError) throw assocError;
 
-            return assocData;
-          } catch (txError) {
-            throw txError;
-          }
+          return assocData;
         },
         undefined, // associationId não é necessário para CREATE
         'CREATE_ASSOCIATION'


### PR DESCRIPTION
## Summary
- simplify error flow in `useCreateAssociation`
- simplify error flow in `useAssociationActions`

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685be7e46bb48325ae60526fecc634f9