### PR TITLE
Update ts error comment

### DIFF
--- a/src/modules/tickets/services/ticketService.ts
+++ b/src/modules/tickets/services/ticketService.ts
@@ -108,7 +108,7 @@ export const fetchTickets = async (filters?: Partial<Ticket>): Promise<Ticket[]>
   
   return mockTickets.filter(ticket => {
     return Object.entries(filters).every(([key, value]) => {
-      // @ts-ignore - We're doing a dynamic filter
+      // @ts-expect-error dynamic property access
       return ticket[key] === value;
     });
   });


### PR DESCRIPTION
## Summary
- fix the comment on dynamic ticket filter to use `@ts-expect-error`

## Testing
- `npm run lint` *(fails: unexpected `any` usage)*

------
https://chatgpt.com/codex/tasks/task_e_685be7edd380832589e77041685474a2