### PR TITLE
Fix date parsing for association state

### DIFF
--- a/src/modules/assets/hooks/useAssetAssociationState.ts
+++ b/src/modules/assets/hooks/useAssetAssociationState.ts
@@ -17,6 +17,14 @@ export const useAssetAssociationState = () => {
       if (savedState) {
         const parsedState = JSON.parse(savedState);
         console.log('🔄 Restored asset association state from sessionStorage:', parsedState);
+
+        if (parsedState.generalConfig) {
+          parsedState.generalConfig.startDate = new Date(parsedState.generalConfig.startDate);
+          if (parsedState.generalConfig.endDate) {
+            parsedState.generalConfig.endDate = new Date(parsedState.generalConfig.endDate);
+          }
+        }
+
         return parsedState;
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure restored asset association state converts stored dates back to Date objects

## Testing
- `npm run lint` *(fails: Unexpected any, lexical declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685bfc53ebb48325999044bd9a2e507f