### PR TITLE
Fix registration state any types

### DIFF
--- a/src/modules/assets/hooks/useAssetRegistrationState.ts
+++ b/src/modules/assets/hooks/useAssetRegistrationState.ts
@@ -2,10 +2,13 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { UseFormReturn } from 'react-hook-form';
+import type {
+  ChipFormValues,
+  EquipmentFormValues,
+} from '../pages/assets/register/types';
 
-interface RegistrationFormData {
-  [key: string]: any;
-}
+type ChipRegistrationData = Partial<ChipFormValues>;
+type EquipmentRegistrationData = Partial<EquipmentFormValues>;
 
 interface AssetRegistrationState {
   // Form type management
@@ -26,8 +29,8 @@ interface AssetRegistrationState {
   networkInfoOpen: boolean;
   
   // Form data
-  chipFormData: RegistrationFormData;
-  equipmentFormData: RegistrationFormData;
+  chipFormData: ChipRegistrationData;
+  equipmentFormData: EquipmentRegistrationData;
   
   // Actions
   setCurrentFormType: (formType: 'chip' | 'equipment') => void;
@@ -39,9 +42,19 @@ interface AssetRegistrationState {
   setTechnicalInfoOpen: (open: boolean) => void;
   setSecurityInfoOpen: (open: boolean) => void;
   setNetworkInfoOpen: (open: boolean) => void;
-  setFormValue: (form: UseFormReturn<any>, key: string, value: any) => void;
-  updateFormData: (data: RegistrationFormData, formType: 'chip' | 'equipment') => void;
-  syncWithForm: (form: UseFormReturn<any>, formType: 'chip' | 'equipment') => void;
+  setFormValue: <T extends ChipFormValues | EquipmentFormValues>(
+    form: UseFormReturn<T>,
+    key: keyof T,
+    value: T[keyof T]
+  ) => void;
+  updateFormData: (
+    data: ChipRegistrationData | EquipmentRegistrationData,
+    formType: 'chip' | 'equipment'
+  ) => void;
+  syncWithForm: (
+    form: UseFormReturn<ChipFormValues | EquipmentFormValues>,
+    formType: 'chip' | 'equipment'
+  ) => void;
   clearState: () => void;
 }
 
@@ -87,9 +100,9 @@ export const useAssetRegistrationState = create<AssetRegistrationState>()(
       
       setFormValue: (form, key, value) => {
         try {
-          form.setValue(key as any, value);
+          form.setValue(key, value);
         } catch (error) {
-          console.warn(`Could not set form value for key: ${key}`, error);
+          console.warn(`Could not set form value for key: ${String(key)}`, error);
         }
       },
       

--- a/src/modules/assets/services/asset/queries.ts
+++ b/src/modules/assets/services/asset/queries.ts
@@ -1,7 +1,15 @@
 
 import { supabase } from "@/integrations/supabase/client";
-import { Asset, AssetLog, StatusRecord } from "@/types/asset";
-import { AssetListParams, AssetStatusByType, ProblemAsset } from "./types";
+import { Asset, AssetLog, StatusRecord, Manufacturer } from "@/types/asset";
+import {
+  AssetListParams,
+  AssetStatusByType,
+  ProblemAsset,
+} from "./types";
+import type { Database } from "@/integrations/supabase/types";
+
+type ProblemAssetFromDb =
+  Database["public"]["Views"]["v_problem_assets"]["Row"];
 import { mapAssetFromDb, mapAssetLogFromDb, mapStatusFromDb } from "./utils";
 
 /**
@@ -196,7 +204,7 @@ export const listProblemAssets = async (): Promise<ProblemAsset[]> => {
     }
 
     // Map the data to ensure it matches ProblemAsset interface
-    return (data || []).map((asset: any) => ({
+    return (data || []).map((asset: ProblemAssetFromDb) => ({
       uuid: asset.uuid,
       id: null,
       radio: asset.radio || null,
@@ -278,13 +286,13 @@ export const getAssetsByMultipleStatus = async (
  */
 export const getManufacturerById = async (
   id: number
-): Promise<any | null> => {
+): Promise<Manufacturer | null> => {
   try {
     const { data, error } = await supabase
       .from("manufacturers")
       .select("*")
       .eq("id", id)
-      .single();
+      .single<Manufacturer>();
 
     if (error) {
       console.error(`Error fetching manufacturer with id ${id}`);

--- a/src/modules/assets/services/asset/utils.ts
+++ b/src/modules/assets/services/asset/utils.ts
@@ -1,16 +1,21 @@
 import { PostgrestError } from "@supabase/supabase-js";
-import { AssetLog, StatusRecord, Asset } from "@/types/asset";
+import { AssetLog, StatusRecord, Asset, DatabaseAsset } from "@/types/asset";
 import { toast } from "@/utils/toast";
 import { mapDatabaseAssetToFrontend } from "@/utils/databaseMappers";
 import { showFriendlyError } from '@/utils/errorTranslator';
 
-export const handleAssetError = (error: PostgrestError | Error | any, context: string) => {
+export const handleAssetError = (
+  error: PostgrestError | Error | unknown,
+  context: string
+) => {
   console.error(`${context}:`, error);
   const friendlyMessage = showFriendlyError(error, context.toLowerCase());
   toast.error(friendlyMessage);
 };
 
-export const mapDatabaseLogToAssetLog = (dbLog: any): AssetLog => {
+export const mapDatabaseLogToAssetLog = (
+  dbLog: AssetLog
+): AssetLog => {
   return {
     id: dbLog.id,
     assoc_id: dbLog.assoc_id,
@@ -26,15 +31,15 @@ export const mapDatabaseLogToAssetLog = (dbLog: any): AssetLog => {
 };
 
 // Database mapper functions for queries
-export const mapAssetFromDb = (dbAsset: any): Asset => {
+export const mapAssetFromDb = (dbAsset: DatabaseAsset): Asset => {
   return mapDatabaseAssetToFrontend(dbAsset);
 };
 
-export const mapAssetLogFromDb = (dbLog: any): AssetLog => {
+export const mapAssetLogFromDb = (dbLog: AssetLog): AssetLog => {
   return mapDatabaseLogToAssetLog(dbLog);
 };
 
-export const mapStatusFromDb = (dbStatus: any): StatusRecord => {
+export const mapStatusFromDb = (dbStatus: StatusRecord): StatusRecord => {
   return {
     id: dbStatus.id,
     status: dbStatus.status,


### PR DESCRIPTION
## Summary
- remove remaining `any` usage in asset service queries
- type mapper functions to use explicit interfaces

## Testing
- `npm run lint` *(fails: 145 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e9af05ae08325a1c1516211221f0d