### PR TITLE
Add persisted state for asset registration forms

### DIFF
--- a/src/modules/assets/hooks/useAssetRegistrationState.ts
+++ b/src/modules/assets/hooks/useAssetRegistrationState.ts
@@ -1,6 +1,5 @@
-
 import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 import { UseFormReturn } from 'react-hook-form';
 import type {
   ChipFormValues,
@@ -14,24 +13,24 @@ interface AssetRegistrationState {
   // Form type management
   currentFormType: 'chip' | 'equipment';
   isInitialized: boolean;
-  
+
   // Asset type (for compatibility)
   assetType: 'CHIP' | 'ROTEADOR';
-  
+
   // Password strength management
   passwordStrength: 'weak' | 'medium' | 'strong';
   allowWeakPassword: boolean;
-  
+
   // UI state management
   basicInfoOpen: boolean;
   technicalInfoOpen: boolean;
   securityInfoOpen: boolean;
   networkInfoOpen: boolean;
-  
+
   // Form data
   chipFormData: ChipRegistrationData;
   equipmentFormData: EquipmentRegistrationData;
-  
+
   // Actions
   setCurrentFormType: (formType: 'chip' | 'equipment') => void;
   setIsInitialized: (initialized: boolean) => void;
@@ -60,87 +59,103 @@ interface AssetRegistrationState {
 
 export const useAssetRegistrationState = create<AssetRegistrationState>()(
   devtools(
-    (set, get) => ({
-      // Initial state
-      currentFormType: 'chip',
-      isInitialized: false,
-      assetType: 'CHIP',
-      passwordStrength: 'weak',
-      allowWeakPassword: false,
-      basicInfoOpen: true,
-      technicalInfoOpen: false,
-      securityInfoOpen: false,
-      networkInfoOpen: false,
-      chipFormData: {},
-      equipmentFormData: {},
-      
-      // Actions
-      setCurrentFormType: (formType) => {
-        set({ 
-          currentFormType: formType,
-          assetType: formType === 'chip' ? 'CHIP' : 'ROTEADOR'
-        });
-      },
-      
-      setIsInitialized: (initialized) => set({ isInitialized: initialized }),
-      
-      setAssetType: (type) => {
-        set({ 
-          assetType: type,
-          currentFormType: type === 'CHIP' ? 'chip' : 'equipment'
-        });
-      },
-      
-      setPasswordStrength: (strength) => set({ passwordStrength: strength }),
-      setAllowWeakPassword: (allow) => set({ allowWeakPassword: allow }),
-      setBasicInfoOpen: (open) => set({ basicInfoOpen: open }),
-      setTechnicalInfoOpen: (open) => set({ technicalInfoOpen: open }),
-      setSecurityInfoOpen: (open) => set({ securityInfoOpen: open }),
-      setNetworkInfoOpen: (open) => set({ networkInfoOpen: open }),
-      
-      setFormValue: (form, key, value) => {
-        try {
-          form.setValue(key, value);
-        } catch (error) {
-          console.warn(`Could not set form value for key: ${String(key)}`, error);
-        }
-      },
-      
-      updateFormData: (data, formType) => {
-        if (formType === 'chip') {
-          set({ chipFormData: { ...get().chipFormData, ...data } });
-        } else {
-          set({ equipmentFormData: { ...get().equipmentFormData, ...data } });
-        }
-      },
-      
-      syncWithForm: (form, formType) => {
-        const currentValues = form.getValues();
-        if (formType === 'chip') {
-          set({ chipFormData: currentValues });
-        } else {
-          set({ equipmentFormData: currentValues });
-        }
-      },
-      
-      clearState: () => {
-        set({
-          currentFormType: 'chip',
-          isInitialized: false,
-          assetType: 'CHIP',
-          passwordStrength: 'weak',
-          allowWeakPassword: false,
-          basicInfoOpen: true,
-          technicalInfoOpen: false,
-          securityInfoOpen: false,
-          networkInfoOpen: false,
-          chipFormData: {},
-          equipmentFormData: {},
-        });
-      },
-    }),
-    {
-      name: 'asset-registration-state',
-    }
+    persist(
+      (set, get) => ({
+        // Initial state
+        currentFormType: 'chip',
+        isInitialized: false,
+        assetType: 'CHIP',
+        passwordStrength: 'weak',
+        allowWeakPassword: false,
+        basicInfoOpen: true,
+        technicalInfoOpen: false,
+        securityInfoOpen: false,
+        networkInfoOpen: false,
+        chipFormData: {},
+        equipmentFormData: {},
+
+        // Actions
+        setCurrentFormType: (formType) => {
+          set({
+            currentFormType: formType,
+            assetType: formType === 'chip' ? 'CHIP' : 'ROTEADOR',
+          });
+        },
+
+        setIsInitialized: (initialized) => set({ isInitialized: initialized }),
+
+        setAssetType: (type) => {
+          set({
+            assetType: type,
+            currentFormType: type === 'CHIP' ? 'chip' : 'equipment',
+          });
+        },
+
+        setPasswordStrength: (strength) => set({ passwordStrength: strength }),
+        setAllowWeakPassword: (allow) => set({ allowWeakPassword: allow }),
+        setBasicInfoOpen: (open) => set({ basicInfoOpen: open }),
+        setTechnicalInfoOpen: (open) => set({ technicalInfoOpen: open }),
+        setSecurityInfoOpen: (open) => set({ securityInfoOpen: open }),
+        setNetworkInfoOpen: (open) => set({ networkInfoOpen: open }),
+
+        setFormValue: (form, key, value) => {
+          try {
+            form.setValue(key, value);
+          } catch (error) {
+            console.warn(`Could not set form value for key: ${String(key)}`, error);
+          }
+        },
+
+        updateFormData: (data, formType) => {
+          if (formType === 'chip') {
+            set({ chipFormData: { ...get().chipFormData, ...data } });
+          } else {
+            set({ equipmentFormData: { ...get().equipmentFormData, ...data } });
+          }
+        },
+
+        syncWithForm: (form, formType) => {
+          const currentValues = form.getValues();
+          if (formType === 'chip') {
+            set({ chipFormData: currentValues });
+          } else {
+            set({ equipmentFormData: currentValues });
+          }
+        },
+
+        clearState: () => {
+          set({
+            currentFormType: 'chip',
+            isInitialized: false,
+            assetType: 'CHIP',
+            passwordStrength: 'weak',
+            allowWeakPassword: false,
+            basicInfoOpen: true,
+            technicalInfoOpen: false,
+            securityInfoOpen: false,
+            networkInfoOpen: false,
+            chipFormData: {},
+            equipmentFormData: {},
+          });
+        },
+      }),
+      {
+        name: 'asset-registration-state',
+        partialize: (state) => ({
+          currentFormType: state.currentFormType,
+          isInitialized: state.isInitialized,
+          assetType: state.assetType,
+          passwordStrength: state.passwordStrength,
+          allowWeakPassword: state.allowWeakPassword,
+          basicInfoOpen: state.basicInfoOpen,
+          technicalInfoOpen: state.technicalInfoOpen,
+          securityInfoOpen: state.securityInfoOpen,
+          networkInfoOpen: state.networkInfoOpen,
+          chipFormData: state.chipFormData,
+          equipmentFormData: state.equipmentFormData,
+        }),
+      }
+    ),
+    { name: 'asset-registration-state' }
   )
 );

--- a/src/modules/assets/pages/assets/register/useFormSetup.ts
+++ b/src/modules/assets/pages/assets/register/useFormSetup.ts
@@ -3,15 +3,19 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { chipSchema, equipmentSchema } from "./schemas";
 import { ChipFormValues, EquipmentFormValues } from "./types";
+import { useAssetRegistrationState } from "@modules/assets/hooks/useAssetRegistrationState";
 
 export function useFormSetup() {
+  const { chipFormData, equipmentFormData } = useAssetRegistrationState();
+
   const chipForm = useForm<ChipFormValues>({
     resolver: zodResolver(chipSchema),
     defaultValues: {
       line_number: undefined,
       iccid: "",
       manufacturer_id: undefined,
-      status_id: 1
+      status_id: 1,
+      ...chipFormData,
     }
   });
 
@@ -32,7 +36,8 @@ export function useFormSetup() {
       admin_user_fabrica: "admin",
       admin_pass_fabrica: "",
       ssid_atual: "",
-      pass_atual: ""
+      pass_atual: "",
+      ...equipmentFormData,
     }
   });
 


### PR DESCRIPTION
## Summary
- persist asset registration store to keep data across page reloads
- initialize asset forms with data from persisted store

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863ecde1754832584abbe8849347aa6