### PR TITLE
Update auth session handling

### DIFF
--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -12,7 +12,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const { signIn, signUp, signOut, technicalError } = useAuthActions(updateState);
   
   // Set up auth session check and subscription
-  useAuthSession(updateState);
+  useAuthSession(updateState, state);
   
   // Get user role from profile
   const userRole: UserRole = state.profile?.role || 'cliente';


### PR DESCRIPTION
## Summary
- pass the current auth state to `useAuthSession`
- refresh profile silently on session events

## Testing
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68642f58e7f88325bda968578cd8695a