### PR TITLE
Fix logout state clearing

### DIFF
--- a/src/hooks/useAuthSession.ts
+++ b/src/hooks/useAuthSession.ts
@@ -139,9 +139,10 @@ export function useAuthSession(
 
             // Clear profile on sign out
             if (event === 'SIGNED_OUT') {
-              updateState({ 
+              updateState({
+                user: null,
                 profile: null,
-                isLoading: false 
+                isLoading: false
               });
               return;
             }


### PR DESCRIPTION
## Summary
- ensure SIGNED_OUT event clears user and profile in auth session

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68642d8eb6f08325b15075c346cba1df