### PR TITLE
Add session activity confirmation modal

### DIFF
--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -12,7 +12,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const { signIn, signUp, signOut, technicalError } = useAuthActions(updateState);
   
   // Set up auth session check and subscription
-  useAuthSession(updateState, state);
+  const sessionDialog = useAuthSession(updateState, state);
   
   // Get user role from profile
   const userRole: UserRole = state.profile?.role || 'cliente';
@@ -47,6 +47,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }}
     >
       {children}
+      {sessionDialog}
     </AuthContext.Provider>
   );
 };

--- a/src/hooks/__tests__/useAuthSession.test.tsx
+++ b/src/hooks/__tests__/useAuthSession.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, vi, expect, beforeEach } from 'vitest'
+import React from 'react'
+import { useAuthSession } from '../useAuthSession'
+import { AuthState } from '@/types/auth'
+import { useAuthActions } from '../useAuthActions'
+
+vi.mock('../useAuthActions')
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: { user: { id: '1' } } } }))
+    }
+  }
+}))
+
+describe('useAuthSession', () => {
+  const baseState: AuthState = { user: null, profile: null, isLoading: false, error: null }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  function Wrapper() {
+    const [state, setState] = React.useState(baseState)
+    const updateState = (s: Partial<AuthState>) => setState(prev => ({ ...prev, ...s }))
+    const dialog = useAuthSession(updateState, state)
+    return <div>{dialog}</div>
+  }
+
+  it('shows dialog when refresh fires', async () => {
+    render(<Wrapper />)
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+    expect(await screen.findByText('Olá, ainda está ai?')).toBeInTheDocument()
+  })
+
+  it('clicking "sim" keeps session', async () => {
+    const signOut = vi.fn()
+    ;(useAuthActions as unknown as vi.Mock).mockReturnValue({ signOut })
+    render(<Wrapper />)
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+    fireEvent.click(await screen.findByText('sim'))
+    expect(signOut).not.toHaveBeenCalled()
+  })
+
+  it('clicking "não" signs out', async () => {
+    const signOut = vi.fn()
+    ;(useAuthActions as unknown as vi.Mock).mockReturnValue({ signOut })
+    render(<Wrapper />)
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+    fireEvent.click(await screen.findByText('não'))
+    expect(signOut).toHaveBeenCalled()
+  })
+})
+


### PR DESCRIPTION
## Summary
- show an AlertDialog from `useAuthSession` after periodic session refreshes
- allow user to keep session or sign out
- close dialog on stay logged and sign out on decline or timeout
- render dialog through `AuthProvider`
- add tests covering dialog logic

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68644b26498083259e0eb2359a08e8f8