### PR TITLE
Fix client imports and lint issues

### DIFF
--- a/src/context/AssetContext.ts
+++ b/src/context/AssetContext.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from 'react';
-import { Asset, Client, StatusRecord } from '@/types/asset';
+import { Asset, StatusRecord } from '@/types/asset';
+import type { Client } from '@/types/client';
 import { AssetHistoryEntry } from '@/types/assetHistory';
 import type { AssetCreateParams, AssetUpdateParams } from '@/modules/assets/services/asset/types';
 

--- a/src/context/AssetProvider.tsx
+++ b/src/context/AssetProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useMemo, ReactNode } from 'react';
-import { Asset, Client, StatusRecord } from '@/types/asset';
+import { Asset, StatusRecord } from '@/types/asset';
+import type { Client } from '@/types/client';
 import { AssetHistoryEntry } from '@/types/assetHistory';
 import { createAsset, updateAsset, deleteAsset } from '@/modules/assets/services/asset/mutations';
 import type { AssetCreateParams, AssetUpdateParams } from '@/modules/assets/services/asset/types';

--- a/src/modules/assets/pages/assets/register/RegisterAssetForm.tsx
+++ b/src/modules/assets/pages/assets/register/RegisterAssetForm.tsx
@@ -5,8 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Wifi, Cpu, Package, Smartphone } from "lucide-react";
 import { useAssetRegistrationState } from '../../../hooks/useAssetRegistrationState';
-import { ChipForm } from '../../../components/assets/ChipForm';
-import { EquipmentForm } from '../../../components/assets/EquipmentForm';
+import ChipForm from '../../../components/assets/ChipForm';
+import EquipmentForm from '../../../components/assets/EquipmentForm';
 import { AssetType } from '@/types/asset';
 
 interface RegisterAssetFormProps {

--- a/src/modules/assets/services/asset/queries.ts
+++ b/src/modules/assets/services/asset/queries.ts
@@ -85,7 +85,9 @@ export const getAssets = async (
       throw error;
     }
 
-    const assets: Asset[] = (data || []).map((item: any) => mapAssetFromDb(item as DatabaseAsset));
+    const assets: Asset[] = (data || []).map(item =>
+      mapAssetFromDb(item as DatabaseAsset)
+    );
 
     return { data: assets, count: count || 0 };
   } catch (error) {
@@ -162,7 +164,9 @@ export const getAssetsByStatus = async (statusId: number): Promise<Asset[]> => {
       throw error;
     }
 
-    const assets: Asset[] = (data || []).map((item: any) => mapAssetFromDb(item as DatabaseAsset));
+    const assets: Asset[] = (data || []).map(item =>
+      mapAssetFromDb(item as DatabaseAsset)
+    );
     console.log(`Retrieved ${assets.length} assets with status ID ${statusId}`);
     return assets;
   } catch (error) {
@@ -202,7 +206,9 @@ export const getAssetsByType = async (typeId: number): Promise<Asset[]> => {
       throw error;
     }
 
-    const assets: Asset[] = (data || []).map((item: any) => mapAssetFromDb(item as DatabaseAsset));
+    const assets: Asset[] = (data || []).map(item =>
+      mapAssetFromDb(item as DatabaseAsset)
+    );
     console.log(`Retrieved ${assets.length} assets with type ID ${typeId}`);
     return assets;
   } catch (error) {
@@ -290,7 +296,9 @@ export const getAssetsByMultipleStatus = async (
       throw error;
     }
 
-    const assets: Asset[] = (data || []).map((item: any) => mapAssetFromDb(item as DatabaseAsset));
+    const assets: Asset[] = (data || []).map(item =>
+      mapAssetFromDb(item as DatabaseAsset)
+    );
     console.log(
       `Retrieved ${assets.length} assets with status IDs ${statusIds.join(
         ", "

--- a/src/modules/associations/components/associations/GroupActionsToolbar.tsx
+++ b/src/modules/associations/components/associations/GroupActionsToolbar.tsx
@@ -34,7 +34,7 @@ export const GroupActionsToolbar: React.FC<GroupActionsToolbarProps> = ({
   const [showBulkEdit, setShowBulkEdit] = useState(false);
   const [showSoftDeleteConfirm, setShowSoftDeleteConfirm] = useState(false);
   const [showAddAssets, setShowAddAssets] = useState(false);
-  const { softDeleteGroup, changeGroupAssociationType } = useGroupActions();
+  const { softDeleteGroup, changeGroupAssociationType, bulkUpdateGroup } = useGroupActions();
 
   const handleSoftDelete = () => {
     softDeleteGroup.mutate(group);
@@ -43,6 +43,11 @@ export const GroupActionsToolbar: React.FC<GroupActionsToolbarProps> = ({
 
   const handleChangeAssociationType = (newType: number) => {
     changeGroupAssociationType.mutate({ group, newType });
+  };
+
+  const handleBulkUpdate = async (updates: Record<string, unknown>) => {
+    await bulkUpdateGroup.mutateAsync({ group, updates });
+    setShowBulkEdit(false);
   };
 
   const activeAssociationsCount = group.associations.filter(a => 
@@ -149,8 +154,10 @@ export const GroupActionsToolbar: React.FC<GroupActionsToolbarProps> = ({
       {/* Dialog de Edição em Lote */}
       <BulkEditDialog
         open={showBulkEdit}
-        onOpenChange={setShowBulkEdit}
-        group={group}
+        onClose={() => setShowBulkEdit(false)}
+        selectedAssociations={group.associations}
+        onBulkUpdate={handleBulkUpdate}
+        isLoading={bulkUpdateGroup.isPending}
       />
 
       {/* Confirmação de Soft Delete */}

--- a/src/modules/associations/hooks/useAssociationsData.ts
+++ b/src/modules/associations/hooks/useAssociationsData.ts
@@ -1,6 +1,8 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import type { PostgrestFilterBuilder } from '@supabase/postgrest-js';
+import type { Database } from '@/integrations/supabase/types';
 import { SearchType } from '@/hooks/useSearchTypeDetection';
 import { Association, StatusFilterType } from '@/types/associations';
 import { sanitizeSearchTerm } from '@/utils/associationsUtils';
@@ -38,7 +40,10 @@ interface AssociationQueryRow {
 
 // Função para aplicar filtro de busca no Supabase apenas para campos específicos (não busca geral)
 const applySupabaseSearch = (
-  query: any, // usando any para evitar conflitos de tipo genérico
+  query: PostgrestFilterBuilder<
+    Database['public'],
+    AssociationQueryRow
+  >,
   term: string,
   type: SearchType
 ) => {

--- a/src/modules/associations/types/index.ts
+++ b/src/modules/associations/types/index.ts
@@ -1,6 +1,6 @@
 
 // Tipos para o módulo de associações
-import type { Client } from '@/types/asset';
+import type { Client } from '@/types/client';
 import type { AssociationGeneralConfig } from '../components/association/AssociationGeneralConfig';
 
 // Type for SelectedAsset from AssetAssociation page

--- a/src/modules/clients/components/clients/ClientDetailsDialog.tsx
+++ b/src/modules/clients/components/clients/ClientDetailsDialog.tsx
@@ -1,6 +1,7 @@
 
 import { useAssets } from "@/context/AssetContext";
-import { Client, Asset, ChipAsset, EquipamentAsset } from "@/types/asset";
+import type { Client } from "@/types/client";
+import { Asset, ChipAsset, EquipamentAsset } from "@/types/asset";
 import { formatDate } from "@/utils/formatDate";
 import { 
   Dialog,

--- a/src/modules/clients/hooks/useClientsData.ts
+++ b/src/modules/clients/hooks/useClientsData.ts
@@ -4,6 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 
 interface Client {
   uuid: string;
+  nome: string;
   empresa: string;
   responsavel: string;
   telefones: string[];
@@ -36,7 +37,7 @@ export const useClientsData = () => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('clients')
-        .select('uuid, empresa, responsavel, telefones, cnpj, email, created_at, updated_at, deleted_at')
+        .select('uuid, nome, empresa, responsavel, telefones, cnpj, email, created_at, updated_at, deleted_at')
         .is('deleted_at', null) // Excluir clientes deletados por padrão
         .order('created_at', { ascending: false });
       
@@ -63,7 +64,8 @@ export const useClientsData = () => {
 
   // Filter clients based on search term and status
   const filteredClients = clients.filter(client => {
-    const matchesSearch = searchTerm === '' || 
+    const matchesSearch = searchTerm === '' ||
+      client.nome.toLowerCase().includes(searchTerm.toLowerCase()) ||
       client.empresa.toLowerCase().includes(searchTerm.toLowerCase()) ||
       client.responsavel.toLowerCase().includes(searchTerm.toLowerCase()) ||
       client.email?.toLowerCase().includes(searchTerm.toLowerCase()) ||

--- a/src/modules/dashboard/hooks/useOperadorasStats.ts
+++ b/src/modules/dashboard/hooks/useOperadorasStats.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
 
 export interface OperadoraStats {
   id: number;
@@ -46,20 +47,22 @@ export const useOperadorasStats = () => {
       // Processar dados e calcular estatísticas
       const operadorasStats: OperadoraStats[] = data.map((operadora) => {
         // Filtrar apenas SIM-cards (chips) desta operadora
-        const chips = operadora.assets?.filter((asset: any) => 
-          asset.asset_solutions?.solution === "CHIP"
-        ) || [];
+        const chips =
+          operadora.assets?.filter(
+            (asset: Database["public"]["Tables"]["assets"]["Row"]) =>
+              asset.asset_solutions?.solution === "CHIP"
+          ) || [];
 
         const total = chips.length;
         
         // Calcular chips em uso (em locação + em assinatura)
-        const emUso = chips.filter((chip: any) => {
+        const emUso = chips.filter((chip: Database["public"]["Tables"]["assets"]["Row"]) => {
           const status = chip.asset_status?.status?.toLowerCase();
           return status === "em locação" || status === "em assinatura";
         }).length;
 
         // Calcular chips disponíveis
-        const disponivel = chips.filter((chip: any) => {
+        const disponivel = chips.filter((chip: Database["public"]["Tables"]["assets"]["Row"]) => {
           const status = chip.asset_status?.status?.toLowerCase();
           return status === "disponível";
         }).length;

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useAssets } from "@/context/AssetContext";
-import { Asset, Client, SubscriptionInfo } from "@/types/asset";
+import { Asset, SubscriptionInfo } from "@/types/asset";
+import type { Client } from "@/types/client";
 import {
   Card,
   CardContent,

--- a/src/pages/WifiAnalyzer.tsx
+++ b/src/pages/WifiAnalyzer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useAssets } from "@/context/AssetContext";
-import { Asset, EquipamentAsset, Client } from "@/types/asset";
+import { Asset, EquipamentAsset } from "@/types/asset";
+import type { Client } from "@/types/client";
 import {
   Card,
   CardContent,

--- a/src/services/idempotencyService.ts
+++ b/src/services/idempotencyService.ts
@@ -8,7 +8,7 @@ export interface ValidationResult {
 }
 
 class IdempotencyService {
-  private cache: Map<string, any> = new Map();
+  private cache: Map<string, { result: unknown; timestamp: number }> = new Map();
   private readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutos
 
   getCachedResult<T>(key: string): T | null {

--- a/src/utils/clientMappers.ts
+++ b/src/utils/clientMappers.ts
@@ -1,9 +1,10 @@
 
 import { Client } from '@/types/client';
+import type { Database } from '@/integrations/supabase/types';
 
 // Mapear dados do banco para o frontend
 export const mapDatabaseClientToFrontend = (
-  dbClient: any
+  dbClient: Database['public']['Tables']['clients']['Row']
 ): Client => {
   return {
     uuid: dbClient.uuid,
@@ -23,7 +24,9 @@ export const mapDatabaseClientToFrontend = (
 };
 
 // Mapear dados do form para inserção no banco
-export const mapFormDataToDatabase = (formData: any) => {
+export const mapFormDataToDatabase = (
+  formData: Database['public']['Tables']['clients']['Insert']
+) => {
   return {
     empresa: formData.empresa.trim(),
     responsavel: formData.responsavel.trim(),

--- a/src/utils/databaseMappers.ts
+++ b/src/utils/databaseMappers.ts
@@ -1,5 +1,6 @@
 
-import { Asset, AssetStatus, AssetType, ChipAsset, EquipamentAsset, SolutionType, Client, AssetClientAssociation, DatabaseAsset } from "@/types/asset";
+import { Asset, AssetStatus, AssetType, ChipAsset, EquipamentAsset, SolutionType, AssetClientAssociation, DatabaseAsset } from "@/types/asset";
+import type { Client } from '@/types/client';
 import { SOLUTION_IDS, getValidAssetStatus } from "./assetUtils";
 
 // Map database status ID to frontend AssetStatus


### PR DESCRIPTION
## Summary
- type default forms for client mappers and queries
- clean up Postgrest query typing for association searching
- remove explicit `any` from asset queries
- type dashboard stats hook using Supabase database rows
- type idempotency service cache entries

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68659dbc29148325aec7c250482dbaeb