### PR TITLE
Add role-aware toast helpers

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -28,7 +28,7 @@ interface HeaderProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 export function Header({ children, className, ...props }: HeaderProps) {
-  const { signOut, isAuthenticated, userRole } = useAuth();
+  const { signOut, isAuthenticated, userRole, profile } = useAuth();
 
   return (
     <header 
@@ -96,7 +96,9 @@ export function Header({ children, className, ...props }: HeaderProps) {
             </DropdownMenuGroup>
             <DropdownMenuSeparator className="bg-legal-primary/20 dark:bg-legal-secondary/20" />
             <DropdownMenuItem
-              onClick={signOut}
+              onClick={() => {
+                signOut(profile?.role);
+              }}
               className="hover:bg-destructive/10 focus:bg-destructive/10 text-destructive"
             >
               <LogOut className="mr-2 h-4 w-4" />

--- a/src/hooks/useAuthActions.ts
+++ b/src/hooks/useAuthActions.ts
@@ -1,6 +1,7 @@
 
 import { useNavigate } from 'react-router-dom';
 import { toast } from '@/utils/toast';
+import { toastLoginSuccess, toastLogoutSuccess } from '@/utils/roleToastMessages';
 import { authService } from '@/services/authService';
 import { profileService } from '@/services/profileService';
 import { useState, useCallback } from 'react';
@@ -313,7 +314,7 @@ export function useAuthActions(updateState: (state: Partial<AuthState>) => void)
               if (import.meta.env.DEV) console.error(err);
             });
           
-          toast.success(`Bem-vindo(a), ${userProfile.username}!`);
+          toastLoginSuccess(userProfile);
           
           const from = window.history.state?.usr?.from?.pathname || '/';
           navigate(from, { replace: true });
@@ -399,7 +400,7 @@ export function useAuthActions(updateState: (state: Partial<AuthState>) => void)
     }
   }, [isAuthProcessing, navigate, updateState]);
 
-  const signOut = useCallback(async () => {
+  const signOut = useCallback(async (role?: UserRole) => {
     if (isAuthProcessing) {
       if (import.meta.env.DEV) console.log('Auth operation already in progress. Ignoring duplicate request.');
       return;
@@ -416,8 +417,11 @@ export function useAuthActions(updateState: (state: Partial<AuthState>) => void)
         error: null,
         isLoading: false
       });
-      
-      toast.success('Você saiu do sistema com sucesso');
+      if (role) {
+        toastLogoutSuccess(role);
+      } else {
+        toast.success('Você saiu do sistema com sucesso');
+      }
       navigate('/login');
       } catch (error: unknown) {
       if (import.meta.env.DEV) console.error('Erro ao fazer logout:', error);

--- a/src/hooks/useAuthSession.tsx
+++ b/src/hooks/useAuthSession.tsx
@@ -52,7 +52,7 @@ export function useAuthSession(
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
-    signOut();
+    signOut(currentState.profile?.role);
   };
 
   useEffect(() => {

--- a/src/types/authContext.ts
+++ b/src/types/authContext.ts
@@ -17,7 +17,7 @@ export interface AuthContextType extends AuthState {
     password: string,
     role?: UserRole
   ) => Promise<{ data: AuthResponse['data']; error: AuthError | null; profileCreated: boolean }>;
-  signOut: () => Promise<void>;
+  signOut: (role?: UserRole) => Promise<void>;
   isAuthenticated: boolean;
   technicalError?: TechnicalErrorInfo | null;
   // Informações adicionais de role

--- a/src/utils/__tests__/roleToastMessages.test.ts
+++ b/src/utils/__tests__/roleToastMessages.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { getLoginSuccessMessage, getLogoutSuccessMessage } from '../roleToastMessages'
+
+const cases = [
+  { role: 'admin', label: 'Administrador' },
+  { role: 'suporte', label: 'Suporte' },
+  { role: 'cliente', label: 'Cliente' },
+  { role: 'user', label: 'Usuário' }
+] as const
+
+describe('role toast message helpers', () => {
+  it('returns role specific login message', () => {
+    cases.forEach(c => {
+      const msg = getLoginSuccessMessage(c.role, 'Joao')
+      expect(msg).toContain(c.label)
+      expect(msg).toContain('Joao')
+    })
+  })
+
+  it('returns role specific logout message', () => {
+    cases.forEach(c => {
+      const msg = getLogoutSuccessMessage(c.role)
+      expect(msg).toContain(c.label)
+    })
+  })
+})

--- a/src/utils/roleToastMessages.ts
+++ b/src/utils/roleToastMessages.ts
@@ -1,0 +1,45 @@
+import { UserRole, UserProfile } from '@/types/auth';
+import { getRoleLabel } from './roleUtils';
+import { toast } from './toast';
+
+export const ROLE_TOAST_MESSAGES: Record<UserRole, { loginSuccess: string; logoutSuccess: string }> = {
+  admin: {
+    loginSuccess: 'Bem-vindo(a), {user}! Você está logado como {role}.',
+    logoutSuccess: '{role} desconectado com sucesso.'
+  },
+  suporte: {
+    loginSuccess: 'Bem-vindo(a), {user}! Acesso de {role} autorizado.',
+    logoutSuccess: '{role} desconectado com sucesso.'
+  },
+  cliente: {
+    loginSuccess: 'Bem-vindo(a), {user}! Você está logado como {role}.',
+    logoutSuccess: 'Sessão de {role} encerrada.'
+  },
+  user: {
+    loginSuccess: 'Bem-vindo(a), {user}! Você está logado como {role}.',
+    logoutSuccess: 'Sessão de {role} encerrada.'
+  }
+};
+
+function format(template: string, role: UserRole, username?: string): string {
+  return template
+    .replace('{role}', getRoleLabel(role))
+    .replace('{user}', username ?? '');
+}
+
+export function getLoginSuccessMessage(role: UserRole, username: string): string {
+  return format(ROLE_TOAST_MESSAGES[role].loginSuccess, role, username);
+}
+
+export function getLogoutSuccessMessage(role: UserRole): string {
+  return format(ROLE_TOAST_MESSAGES[role].logoutSuccess, role);
+}
+
+export function toastLoginSuccess(profile: UserProfile) {
+  toast.success(getLoginSuccessMessage(profile.role, profile.username));
+}
+
+export function toastLogoutSuccess(role: UserRole) {
+  toast.success(getLogoutSuccessMessage(role));
+}
+


### PR DESCRIPTION
## Summary
- map toast messages per role
- provide helpers and a React hook for role-aware toasts
- use new helpers in auth flows and header dropdown
- support specifying role on sign out
- test toast helpers
- remove duplicate logout toasts
- remove unused `useRoleToasts` hook

## Testing
- `npx vitest run` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6866aad17ba8832583588f5f3ccfef7e