### PR TITLE
Setup basic Vitest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build -m production",
     "build:dev": "vite build -m development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -82,6 +83,10 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^22.1.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@modules': path.resolve(__dirname, './src/modules'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add `test` script using Vitest
- set up `vitest.config.ts` with jsdom and aliases
- include testing libs as dev dependencies

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bce346c88325be32b54c4332aebe