### PR TITLE
Document auth guard usage in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,16 @@ cp .env.production .env    # for production builds
 
 You can also create a custom `.env` file based on these examples.
 
+
+## Auth Protection Components
+
+Reusable guard components live in `src/components/auth`. They help enforce authentication and role-based permissions across the application.
+
+```tsx
+<AuthRoute requiredRole="admin">
+  <AdminPage />
+</AuthRoute>
+```
+
+See [src/components/auth/README.md](src/components/auth/README.md) for a full list of components and additional examples.
+

--- a/src/components/auth/README.md
+++ b/src/components/auth/README.md
@@ -1,0 +1,52 @@
+# Auth Protection Components
+
+This folder contains reusable components to protect routes and interface elements.
+They rely on `AuthProvider` and `useAuth` to read the current user session.
+
+## Components
+
+- **AuthRoute** – Wraps a route element and redirects to `/login` when the user
+  is not authenticated. You can specify a `requiredRole` to restrict access.
+- **PrivateRoute** – Simplified variant that defaults to the `admin` role.
+- **ProtectedRoute** – Displays optional fallback content or the
+  `InsufficientPermissions` message when the user lacks permission.
+- **RoleGuard** – Conditionally renders its children based on role checks.
+- **PermissionButton** – Button that becomes disabled with a tooltip when the
+  user does not have the required role.
+- **InsufficientPermissions** – Standard alert shown by the guards when access is
+  denied.
+
+## Usage Examples
+
+### Protecting a Route
+```tsx
+<Route
+  path="/admin"
+  element={
+    <AuthRoute requiredRole="admin">
+      <AdminPage />
+    </AuthRoute>
+  }
+/>
+```
+
+### Conditional Rendering
+```tsx
+<RoleGuard requiredRole="suporte">
+  <SensitiveComponent />
+</RoleGuard>
+```
+
+### Button with Permission Check
+```tsx
+<PermissionButton requiredRole="admin" tooltip="Somente administradores">
+  Ação Restrita
+</PermissionButton>
+```
+
+### Custom Message with ProtectedRoute
+```tsx
+<ProtectedRoute requiredRole="suporte" customMessage="Acesso apenas para suporte">
+  <SupportPage />
+</ProtectedRoute>
+```


### PR DESCRIPTION
## Summary
- add README for auth guard components inside `src/components/auth`
- update project README with a quick example and link to detailed docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866c019da7c8325bfefaae8d2353098