### PR TITLE
Fix safedParseInt and add tests

### DIFF
--- a/src/utils/__tests__/stringUtils.test.ts
+++ b/src/utils/__tests__/stringUtils.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { safedParseInt } from '../stringUtils'
+
+describe('safedParseInt', () => {
+  it('parses valid numbers', () => {
+    expect(safedParseInt('123')).toBe(123)
+    expect(safedParseInt('0')).toBe(0)
+  })
+
+  it('returns -1 for invalid numbers', () => {
+    expect(safedParseInt('abc')).toBe(-1)
+    expect(safedParseInt('')).toBe(-1)
+  })
+})

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -13,14 +13,9 @@ export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }
 
-export function safedParseInt(searchTerm: string) {
-  const parsedSearchTerm = parseInt(searchTerm);
-  const parsedType = typeof parsedSearchTerm;
-  if (parsedType !== 'bigint') {
-    return -1;
-  } else {
-    return parsedSearchTerm;
-  }
+export function safedParseInt(searchTerm: string): number {
+  const parsed = parseInt(searchTerm, 10)
+  return Number.isNaN(parsed) ? -1 : parsed
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix `safedParseInt` so it returns parsed numbers
- add unit tests for `safedParseInt`

## Testing
- `npm run lint` *(fails: Parsing error in src/types/client.ts)*
- `npx vitest run` *(fails: npm 403 Forbidden - registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867d8870e008325bcd8aade8ff0c370