### PR TITLE
Fix missing props in AssociationSummary

### DIFF
--- a/src/modules/associations/components/association/AssetAssociation.tsx
+++ b/src/modules/associations/components/association/AssetAssociation.tsx
@@ -202,7 +202,16 @@ export const AssetAssociation: React.FC = () => {
         <CardContent>
           {currentStep === 'client' && <ClientSelectionStep />}
           {currentStep === 'assets' && <AssetSelectionStep />}
-          {currentStep === 'summary' && <AssociationSummary />}
+          {currentStep === 'summary' && selectedClient && generalConfig && (
+            <AssociationSummary
+              client={selectedClient}
+              assets={selectedAssets}
+              generalConfig={generalConfig}
+              onComplete={handleSubmit}
+              onBack={handleBack}
+              isLoading={isSubmitting}
+            />
+          )}
 
           {/* Navigation Buttons */}
           <div className="flex justify-between mt-6">


### PR DESCRIPTION
## Summary
- ensure `AssetAssociation` passes the proper props to `AssociationSummary`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867ec6a1edc8325a8dd3fe0056d07f8