### PR TITLE
Switch to new associations table

### DIFF
--- a/src/modules/assets/services/asset/associationQueries.ts
+++ b/src/modules/assets/services/asset/associationQueries.ts
@@ -18,7 +18,7 @@ export const associationQueries = {
       if (import.meta.env.DEV) console.log(`Checking active associations for asset: ${assetId}`);
       
       const { data, error } = await supabase
-        .from('asset_client_assoc')
+        .from('associations')
         .select(`
           id,
           client_id,
@@ -28,7 +28,7 @@ export const associationQueries = {
           clients!inner(nome),
           association_types!inner(type)
         `)
-        .eq('asset_id', assetId)
+        .or(`equipment_id.eq.${assetId},chip_id.eq.${assetId}`)
         .is('exit_date', null)
         .is('deleted_at', null);
 

--- a/src/modules/assets/services/history/historyService.ts
+++ b/src/modules/assets/services/history/historyService.ts
@@ -48,14 +48,22 @@ interface AssetLogWithRelationsRaw {
   fk_asset_logs_status_before?: { status: string } | null;
   fk_asset_logs_status_after?: { status: string } | null;
   fk_asset_logs_assoc_id?: {
-    asset?: {
+    equipment?: {
       uuid: string;
       serial_number?: string;
       model?: string;
       iccid?: string;
       radio?: string;
       line_number?: number;
-    };
+    } | null;
+    chip?: {
+      uuid: string;
+      serial_number?: string;
+      model?: string;
+      iccid?: string;
+      radio?: string;
+      line_number?: number;
+    } | null;
     client?: {
       uuid: string;
       nome: string;
@@ -80,8 +88,16 @@ export const getAssetLogsWithRelations = async (): Promise<AssetLogWithRelations
         assoc_id,
         fk_asset_logs_status_before:asset_status!fk_asset_logs_status_before(status),
         fk_asset_logs_status_after:asset_status!fk_asset_logs_status_after(status),
-        fk_asset_logs_assoc_id:asset_client_assoc!left(
-          asset:assets!asset_id(
+        fk_asset_logs_assoc_id:associations!left(
+          equipment:assets!equipment_id(
+            uuid,
+            serial_number,
+            model,
+            iccid,
+            radio,
+            line_number
+          ),
+          chip:assets!chip_id(
             uuid,
             serial_number,
             model,

--- a/src/modules/associations/components/associations/EditAssociationDialog.tsx
+++ b/src/modules/associations/components/associations/EditAssociationDialog.tsx
@@ -52,7 +52,7 @@ export const EditAssociationDialog: React.FC<EditAssociationDialogProps> = ({
 
     try {
       const { error } = await supabase
-        .from('asset_client_assoc')
+        .from('associations')
         .update({
           entry_date: formData.entry_date,
           exit_date: formData.exit_date || null,

--- a/src/modules/associations/components/associations/EditGroupAssociationDialog.tsx
+++ b/src/modules/associations/components/associations/EditGroupAssociationDialog.tsx
@@ -92,7 +92,7 @@ export const EditGroupAssociationDialog: React.FC<EditGroupAssociationDialogProp
         }
 
         const { error } = await supabase
-          .from('asset_client_assoc')
+          .from('associations')
           .update(updateData)
           .eq('id', association.id);
 

--- a/src/modules/associations/hooks/useAssetSearch.ts
+++ b/src/modules/associations/hooks/useAssetSearch.ts
@@ -99,14 +99,14 @@ export const useAssetSearch = ({
       if (excludeAssociatedToClient) {
         if (import.meta.env.DEV) console.log('useAssetSearch: Excluindo assets já associados ao cliente:', excludeAssociatedToClient);
         const { data: associatedAssets } = await supabase
-          .from('asset_client_assoc')
-          .select('asset_id')
+          .from('associations')
+          .select('equipment_id, chip_id')
           .eq('client_id', excludeAssociatedToClient)
           .is('exit_date', null)
           .is('deleted_at', null);
 
         if (associatedAssets && associatedAssets.length > 0) {
-          const associatedAssetIds = associatedAssets.map(assoc => assoc.asset_id);
+          const associatedAssetIds = associatedAssets.map(assoc => assoc.equipment_id || assoc.chip_id);
           query = query.not('uuid', 'in', `(${associatedAssetIds.join(',')})`);
         }
       }

--- a/src/modules/associations/hooks/useAssociationActions.ts
+++ b/src/modules/associations/hooks/useAssociationActions.ts
@@ -33,12 +33,12 @@ export const useAssociationActions = () => {
           // Usar transação manual sem RPC functions
           // Encerrar associação (definir exit_date)
           const { data: assocData, error: assocError } = await supabase
-            .from('asset_client_assoc')
+            .from('associations')
             .update({
               exit_date: new Date().toISOString().split('T')[0] // Data atual
             })
             .eq('id', associationId)
-            .eq('asset_id', assetId)
+            .or(`equipment_id.eq.${assetId},chip_id.eq.${assetId}`)
             .is('exit_date', null) // Só atualizar se ainda não tem exit_date
             .select()
             .single();

--- a/src/modules/associations/hooks/useAssociationsData.ts
+++ b/src/modules/associations/hooks/useAssociationsData.ts
@@ -22,7 +22,8 @@ interface UseAssociationsDataProps {
 
 interface AssociationQueryRow {
   id: number;
-  asset_id: string;
+  equipment_id: string | null;
+  chip_id: string | null;
   client_id: string;
   entry_date: string;
   exit_date: string | null;
@@ -97,10 +98,11 @@ export const useAssociationsData = ({
       }
 
       let query = supabase
-        .from('asset_client_assoc')
+        .from('associations')
         .select(`
           id,
-          asset_id,
+          equipment_id,
+          chip_id,
           client_id,
           entry_date,
           exit_date,
@@ -167,7 +169,7 @@ export const useAssociationsData = ({
       // Mapear dados para o formato esperado com line_number incluído
       const mappedData: Association[] = data.map((item: AssociationQueryRow) => ({
         id: item.id,
-        asset_id: item.asset_id,
+        asset_id: item.equipment_id || item.chip_id,
         client_id: item.client_id,
         entry_date: item.entry_date,
         exit_date: item.exit_date,

--- a/src/modules/associations/hooks/useCreateAssociation.ts
+++ b/src/modules/associations/hooks/useCreateAssociation.ts
@@ -115,7 +115,8 @@ export const useCreateAssociation = () => {
 
       // Preparar dados para inserção direta
       const insertPayload = data.selectedAssets.map(asset => ({
-        asset_id: asset.id,
+        equipment_id: asset.type === 'CHIP' ? null : asset.id,
+        chip_id: asset.type === 'CHIP' ? asset.id : null,
         client_id: data.clientId,
         association_id: data.associationTypeId,
         entry_date: formattedStartDate,
@@ -135,7 +136,7 @@ export const useCreateAssociation = () => {
           if (import.meta.env.DEV) console.log('[useCreateAssociation] Inserindo associações diretamente...');
 
           const { data: inserted, error } = await supabase
-            .from('asset_client_assoc')
+            .from('associations')
             .insert(insertPayload)
             .select('id');
 

--- a/src/modules/associations/hooks/useGroupActions.ts
+++ b/src/modules/associations/hooks/useGroupActions.ts
@@ -39,7 +39,7 @@ export const useGroupActions = () => {
       const results = [];
       for (const id of associationIds) {
         const { error } = await supabase
-          .from('asset_client_assoc')
+          .from('associations')
           .update({ 
             deleted_at: new Date().toISOString(),
             updated_at: new Date().toISOString()
@@ -78,7 +78,7 @@ export const useGroupActions = () => {
       const results = [];
       for (const id of associationIds) {
         const { error } = await supabase
-          .from('asset_client_assoc')
+          .from('associations')
           .update({ 
             ...updates,
             updated_at: new Date().toISOString()
@@ -117,7 +117,7 @@ export const useGroupActions = () => {
       const results = [];
       for (const id of associationIds) {
         const { error } = await supabase
-          .from('asset_client_assoc')
+          .from('associations')
           .update({ 
             association_id: newType,
             updated_at: new Date().toISOString()
@@ -165,7 +165,7 @@ export const useGroupActions = () => {
       const results = [];
       for (const id of associationIds) {
         const { error } = await supabase
-          .from('asset_client_assoc')
+          .from('associations')
           .update({ 
             exit_date: today,
             updated_at: new Date().toISOString()

--- a/src/modules/dashboard/hooks/useDashboardWithFilters.ts
+++ b/src/modules/dashboard/hooks/useDashboardWithFilters.ts
@@ -73,17 +73,17 @@ export function useDashboardWithFilters(): UseDashboardWithFiltersResult {
         }
       }
       
-      // Client filter requires a join with asset_client_assoc
+      // Client filter requires a join with associations
       if (filters.client) {
         // Get asset IDs associated with the selected client
         const { data: associatedAssets } = await supabase
-          .from('asset_client_assoc')
-          .select('asset_id')
+          .from('associations')
+          .select('equipment_id, chip_id')
           .eq('client_id', filters.client)
           .is('exit_date', null);
-        
+
         // Extract asset_ids from the result
-        const assetIds = associatedAssets?.map(item => item.asset_id) || [];
+        const assetIds = associatedAssets?.map(item => item.equipment_id || item.chip_id) || [];
         
         // Apply the filter only if we have asset IDs
         if (assetIds.length > 0) {

--- a/src/modules/dashboard/hooks/useLeaseAssets.ts
+++ b/src/modules/dashboard/hooks/useLeaseAssets.ts
@@ -19,11 +19,12 @@ export const useLeaseAssets = () => {
         }
         
         // Query para buscar ativos atualmente em locação (association_id = 1)
-        // Usando asset_client_assoc para identificar ativos associados
+        // Usando associations para identificar ativos associados
         const { data: leaseAssociations, error } = await supabase
-          .from('asset_client_assoc')
+          .from('associations')
           .select(`
-            asset_id,
+            equipment_id,
+            chip_id,
             association_id,
             exit_date,
             assets!inner(

--- a/src/modules/dashboard/hooks/useSubscriptionAssets.ts
+++ b/src/modules/dashboard/hooks/useSubscriptionAssets.ts
@@ -19,11 +19,12 @@ export const useSubscriptionAssets = () => {
         }
         
         // Query para buscar ativos atualmente em assinatura (association_id = 2)
-        // Usando asset_client_assoc para identificar ativos associados
+        // Usando associations para identificar ativos associados
         const { data: subscriptionAssociations, error } = await supabase
-          .from('asset_client_assoc')
+          .from('associations')
           .select(`
-            asset_id,
+            equipment_id,
+            chip_id,
             association_id,
             exit_date,
             assets!inner(

--- a/src/modules/dashboard/services/dashboardQueries.ts
+++ b/src/modules/dashboard/services/dashboardQueries.ts
@@ -173,10 +173,11 @@ export async function fetchActiveAssociations() {
     if (import.meta.env.DEV) console.log('Executing fetchActiveAssociations query (optimized)');
   }
   const result = await supabase
-    .from('asset_client_assoc')
-    .select(`
+    .from('associations')
+      .select(`
       id,
-      asset_id,
+      equipment_id,
+      chip_id,
       client_id,
       association_id,
       entry_date,
@@ -211,10 +212,11 @@ export async function fetchAssociationsEndingToday() {
   }
   const today = new Date().toISOString().split('T')[0];
   const result = await supabase
-    .from('asset_client_assoc')
+    .from('associations')
     .select(`
       id,
-      asset_id,
+      equipment_id,
+      chip_id,
       client_id,
       association_id,
       entry_date,
@@ -237,7 +239,7 @@ export async function fetchTopClientsWithAssociations() {
     if (import.meta.env.DEV) console.log('Executing fetchTopClientsWithAssociations query');
   }
   const result = await supabase
-    .from('asset_client_assoc')
+    .from('associations')
     .select(`
       client_id,
       clients!inner(empresa)
@@ -260,7 +262,7 @@ export async function fetchAssociationsLast30Days() {
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   
   const result = await supabase
-    .from('asset_client_assoc')
+    .from('associations')
     .select(`
       id,
       association_id,

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -178,7 +178,7 @@ export interface AssetLog {
   created_at: string; // timestamp NOT NULL
 }
 
-// Interface corrigida para alinhar com tabela 'asset_client_assoc' do banco
+// Interface corrigida para alinhar com tabela 'associations' do banco
 export interface AssetClientAssociation {
   id: number; // bigint NOT NULL (sequence)
   asset_id: string; // text NOT NULL

--- a/src/utils/databaseMappers.ts
+++ b/src/utils/databaseMappers.ts
@@ -149,7 +149,7 @@ export const mapDatabaseClientToFrontend = (dbClient: unknown): Client => {
   };
 };
 
-// Map database asset_client_assoc to frontend type - corrigido conforme banco
+// Map database associations to frontend type - corrigido conforme banco
 export const mapDatabaseAssocToFrontend = (dbAssoc: unknown): AssetClientAssociation => {
   if (!dbAssoc) return null;
   


### PR DESCRIPTION
## Summary
- update supabase queries and mutations to use the new `associations` table
- fetch equipment or chip IDs when selecting assets
- tweak hooks to map equipment and chip identifiers

## Testing
- `npm run lint` *(fails: Parsing error in supabase types)*

------
https://chatgpt.com/codex/tasks/task_e_686c2e38504483259e28a6a251f4307e