### PR TITLE
Update association asset_id mapping

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "src/integrations/supabase/types.ts"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/src/modules/assets/services/asset/associationQueries.ts
+++ b/src/modules/assets/services/asset/associationQueries.ts
@@ -18,17 +18,19 @@ export const associationQueries = {
       if (import.meta.env.DEV) console.log(`Checking active associations for asset: ${assetId}`);
       
       const { data, error } = await supabase
-        .from('asset_client_assoc')
+        .from('associations')
         .select(`
-          id,
+          uuid,
           client_id,
-          association_id,
+          association_type_id,
           entry_date,
           exit_date,
           clients!inner(nome),
-          association_types!inner(type)
+          association_types!inner(type),
+          equipment_id,
+          chip_id
         `)
-        .eq('asset_id', assetId)
+        .or(`equipment_id.eq.${assetId},chip_id.eq.${assetId}`)
         .is('exit_date', null)
         .is('deleted_at', null);
 
@@ -38,9 +40,9 @@ export const associationQueries = {
       }
 
       const associations: AssetAssociation[] = (data || []).map(item => ({
-        id: item.id,
+        id: item.uuid,
         client_id: item.client_id,
-        association_id: item.association_id,
+        association_id: item.association_type_id,
         entry_date: item.entry_date,
         exit_date: item.exit_date,
         client_name: (item.clients as { nome?: string } | null)?.nome || 'Cliente não encontrado',

--- a/src/modules/associations/components/associations/AddAssetsDialog.tsx
+++ b/src/modules/associations/components/associations/AddAssetsDialog.tsx
@@ -104,7 +104,7 @@ export const AddAssetsDialog: React.FC<AddAssetsDialogProps> = ({
         client_id: existingAssociation.client_id,
         association_id: existingAssociation.association_id,
         entry_date: existingAssociation.entry_date,
-        asset_ids: selectedAssets.map(asset => asset.uuid),
+        assets: selectedAssets.map(asset => ({ id: asset.uuid, type: asset.type })),
         exit_date: existingAssociation.exit_date,
         notes: existingAssociation.notes,
         ssid: existingAssociation.ssid,

--- a/src/modules/associations/hooks/useAssetSearch.ts
+++ b/src/modules/associations/hooks/useAssetSearch.ts
@@ -99,14 +99,14 @@ export const useAssetSearch = ({
       if (excludeAssociatedToClient) {
         if (import.meta.env.DEV) console.log('useAssetSearch: Excluindo assets já associados ao cliente:', excludeAssociatedToClient);
         const { data: associatedAssets } = await supabase
-          .from('asset_client_assoc')
-          .select('asset_id')
+          .from('associations')
+          .select('equipment_id, chip_id')
           .eq('client_id', excludeAssociatedToClient)
           .is('exit_date', null)
           .is('deleted_at', null);
 
         if (associatedAssets && associatedAssets.length > 0) {
-          const associatedAssetIds = associatedAssets.map(assoc => assoc.asset_id);
+          const associatedAssetIds = associatedAssets.map(assoc => assoc.equipment_id || assoc.chip_id);
           query = query.not('uuid', 'in', `(${associatedAssetIds.join(',')})`);
         }
       }

--- a/src/modules/associations/hooks/useAssociationActions.ts
+++ b/src/modules/associations/hooks/useAssociationActions.ts
@@ -33,13 +33,14 @@ export const useAssociationActions = () => {
           // Usar transação manual sem RPC functions
           // Encerrar associação (definir exit_date)
           const { data: assocData, error: assocError } = await supabase
-            .from('asset_client_assoc')
+            .from('associations')
             .update({
-              exit_date: new Date().toISOString().split('T')[0] // Data atual
+              exit_date: new Date().toISOString().split('T')[0],
+              status: false
             })
-            .eq('id', associationId)
-            .eq('asset_id', assetId)
-            .is('exit_date', null) // Só atualizar se ainda não tem exit_date
+            .eq('uuid', associationId)
+            .or(`equipment_id.eq.${assetId},chip_id.eq.${assetId}`)
+            .is('exit_date', null)
             .select()
             .single();
 

--- a/src/modules/associations/hooks/useCreateAssociation.ts
+++ b/src/modules/associations/hooks/useCreateAssociation.ts
@@ -115,15 +115,15 @@ export const useCreateAssociation = () => {
 
       // Preparar dados para inserção direta
       const insertPayload = data.selectedAssets.map(asset => ({
-        asset_id: asset.id,
         client_id: data.clientId,
-        association_id: data.associationTypeId,
+        association_type_id: data.associationTypeId,
         entry_date: formattedStartDate,
         exit_date: data.endDate ? new Date(data.endDate).toISOString().split('T')[0] : null,
         notes: data.generalConfig?.notes || null,
-        ssid: data.generalConfig?.ssid || null,
-        pass: data.generalConfig?.password || null,
-        gb: data.generalConfig?.dataLimit || null
+        equipment_ssid: data.generalConfig?.ssid || null,
+        equipment_pass: data.generalConfig?.password || null,
+        plan_gb: data.generalConfig?.dataLimit || null,
+        ...(asset.type === 'CHIP' ? { chip_id: asset.id } : { equipment_id: asset.id })
       }));
 
       if (import.meta.env.DEV) console.log('[useCreateAssociation] Payload de inserção:', insertPayload);
@@ -135,16 +135,16 @@ export const useCreateAssociation = () => {
           if (import.meta.env.DEV) console.log('[useCreateAssociation] Inserindo associações diretamente...');
 
           const { data: inserted, error } = await supabase
-            .from('asset_client_assoc')
+            .from('associations')
             .insert(insertPayload)
-            .select('id');
+            .select('uuid');
 
           if (error) {
             if (import.meta.env.DEV) console.error('[useCreateAssociation] Erro do Supabase:', error);
             throw new Error(error.message || 'Erro desconhecido ao criar associação');
           }
 
-          const insertedIds = inserted ? inserted.map(rec => rec.id as number) : [];
+          const insertedIds = inserted ? inserted.map(rec => rec.uuid as string) : [];
 
           const result = buildInsertResult(insertedIds, insertPayload.length);
 

--- a/src/modules/dashboard/hooks/useDashboardWithFilters.ts
+++ b/src/modules/dashboard/hooks/useDashboardWithFilters.ts
@@ -77,13 +77,13 @@ export function useDashboardWithFilters(): UseDashboardWithFiltersResult {
       if (filters.client) {
         // Get asset IDs associated with the selected client
         const { data: associatedAssets } = await supabase
-          .from('asset_client_assoc')
-          .select('asset_id')
+          .from('associations')
+          .select('equipment_id, chip_id')
           .eq('client_id', filters.client)
           .is('exit_date', null);
-        
+
         // Extract asset_ids from the result
-        const assetIds = associatedAssets?.map(item => item.asset_id) || [];
+        const assetIds = associatedAssets?.map(item => item.equipment_id || item.chip_id) || [];
         
         // Apply the filter only if we have asset IDs
         if (assetIds.length > 0) {

--- a/src/modules/dashboard/services/dashboardQueries.ts
+++ b/src/modules/dashboard/services/dashboardQueries.ts
@@ -173,17 +173,29 @@ export async function fetchActiveAssociations() {
     if (import.meta.env.DEV) console.log('Executing fetchActiveAssociations query (optimized)');
   }
   const result = await supabase
-    .from('asset_client_assoc')
+    .from('associations')
     .select(`
-      id,
-      asset_id,
+      uuid,
       client_id,
-      association_id,
+      association_type_id,
       entry_date,
       exit_date,
       clients!inner(empresa),
       association_types!inner(type),
-      assets!inner(
+      equipment_id,
+      chip_id,
+      assets:assets!equipment_id(
+        uuid,
+        serial_number,
+        radio,
+        line_number,
+        rented_days,
+        status_id,
+        solution_id,
+        asset_solutions!inner(solution),
+        asset_status!inner(status)
+      ),
+      chip_assets:assets!chip_id(
         uuid,
         serial_number,
         radio,
@@ -211,14 +223,15 @@ export async function fetchAssociationsEndingToday() {
   }
   const today = new Date().toISOString().split('T')[0];
   const result = await supabase
-    .from('asset_client_assoc')
+    .from('associations')
     .select(`
-      id,
-      asset_id,
+      uuid,
       client_id,
-      association_id,
+      association_type_id,
       entry_date,
       exit_date,
+      equipment_id,
+      chip_id,
       clients!inner(empresa),
       association_types!inner(type)
     `)
@@ -237,7 +250,7 @@ export async function fetchTopClientsWithAssociations() {
     if (import.meta.env.DEV) console.log('Executing fetchTopClientsWithAssociations query');
   }
   const result = await supabase
-    .from('asset_client_assoc')
+    .from('associations')
     .select(`
       client_id,
       clients!inner(empresa)
@@ -260,10 +273,10 @@ export async function fetchAssociationsLast30Days() {
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   
   const result = await supabase
-    .from('asset_client_assoc')
+    .from('associations')
     .select(`
-      id,
-      association_id,
+      uuid,
+      association_type_id,
       entry_date,
       exit_date,
       created_at,

--- a/src/types/associations.ts
+++ b/src/types/associations.ts
@@ -11,7 +11,7 @@ export interface AssociationGroup {
 }
 
 export interface Association {
-  id: number;
+  id: string;
   asset_id: string;
   client_id: string;
   entry_date: string;


### PR DESCRIPTION
## Summary
- refactor AddAssetsService to insert chip/equipment IDs into `associations`
- adjust AddAssetsDialog to send asset type info
- support chip/equipment logic when creating associations
- query associations by chip/equipment IDs in asset search and dashboard hooks
- update association queries and types
- ignore generated supabase types in ESLint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686cfd5400d883259e50b21ac5f2461a