### PR TITLE
Fix status ID retrieval in trigger function

### DIFF
--- a/supabase/migrations/20250708180000_refactor-log_and_update_status_subroutines.sql
+++ b/supabase/migrations/20250708180000_refactor-log_and_update_status_subroutines.sql
@@ -232,7 +232,7 @@ BEGIN
   client_name := get_client_name(NEW.client_id);
   solution_name := get_solution_name(asset_info.solution_id);
 
-  ids := load_status_ids();
+  SELECT * INTO ids FROM load_status_ids();
 
   valid_assoc_id := validate_assoc_id(NEW.id, OLD.id);
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -741,7 +741,7 @@ BEGIN
   client_name := get_client_name(NEW.client_id);
   solution_name := get_solution_name(asset_info.solution_id);
 
-  ids := load_status_ids();
+  SELECT * INTO ids FROM load_status_ids();
 
   valid_assoc_id := validate_assoc_id(NEW.id, OLD.id);
 


### PR DESCRIPTION
## Summary
- use `SELECT ... INTO` to capture status IDs in the migration and schema

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d688417b48325a4de8f73a5a6ec5f