### PR TITLE
Implement new logging migrations

### DIFF
--- a/supabase/migrations/20250708180000_create_new_logging_tables.sql
+++ b/supabase/migrations/20250708180000_create_new_logging_tables.sql
@@ -1,0 +1,68 @@
+BEGIN;
+
+-- Drop triggers on old asset_logs table
+DROP TRIGGER IF EXISTS asset_histories_log_trigger ON public.asset_logs;
+DROP TRIGGER IF EXISTS asset_histories_log_trigger_before_delete ON public.asset_logs;
+DROP TRIGGER IF EXISTS set_asset_logs_updated_at ON public.asset_logs;
+
+-- Rename existing table to keep historical data
+ALTER TABLE public.asset_logs RENAME TO asset_logs_legacy;
+
+-- Ensure sequence ownership follows the renamed table
+ALTER SEQUENCE IF EXISTS public.asset_history_id_seq OWNED BY public.asset_logs_legacy.id;
+
+-- Create association_logs table
+CREATE TABLE public.association_logs (
+    uuid uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES profiles(id),
+    association_uuid uuid NOT NULL REFERENCES associations(uuid),
+    event text NOT NULL,
+    details jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE TRIGGER set_association_logs_updated_at
+BEFORE UPDATE ON public.association_logs
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX idx_association_logs_association_uuid ON public.association_logs(association_uuid);
+CREATE INDEX idx_association_logs_user_id ON public.association_logs(user_id);
+CREATE INDEX idx_association_logs_deleted_at ON public.association_logs(deleted_at);
+
+ALTER TABLE public.association_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Auth users can insert" ON public.association_logs FOR INSERT TO authenticated WITH CHECK (true);
+CREATE POLICY "Auth users can update" ON public.association_logs FOR UPDATE TO authenticated USING (true);
+CREATE POLICY "Enable read access for all users" ON public.association_logs FOR SELECT USING (true);
+CREATE POLICY "admin_total_access" ON public.association_logs TO authenticated USING (public.is_admin()) WITH CHECK (public.is_admin());
+
+-- Create new asset_logs table using UUIDs
+CREATE TABLE public.asset_logs (
+    uuid uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES profiles(id),
+    asset_id text NOT NULL REFERENCES assets(uuid),
+    event text NOT NULL,
+    details jsonb NOT NULL,
+    status_before_id bigint REFERENCES asset_status(id),
+    status_after_id bigint REFERENCES asset_status(id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE TRIGGER set_asset_logs_updated_at
+BEFORE UPDATE ON public.asset_logs
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX idx_asset_logs_asset_id ON public.asset_logs(asset_id);
+CREATE INDEX idx_asset_logs_user_id ON public.asset_logs(user_id);
+CREATE INDEX idx_asset_logs_deleted_at ON public.asset_logs(deleted_at);
+
+ALTER TABLE public.asset_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Auth users can insert" ON public.asset_logs FOR INSERT TO authenticated WITH CHECK (true);
+CREATE POLICY "Auth users can update" ON public.asset_logs FOR UPDATE TO authenticated USING (true);
+CREATE POLICY "Enable read access for all users" ON public.asset_logs FOR SELECT USING (true);
+CREATE POLICY "admin_total_access" ON public.asset_logs TO authenticated USING (public.is_admin()) WITH CHECK (public.is_admin());
+
+COMMIT;

--- a/supabase/migrations/20250708180100_migrate_old_logs.sql
+++ b/supabase/migrations/20250708180100_migrate_old_logs.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+-- Migrate association events
+INSERT INTO public.association_logs (uuid, user_id, association_uuid, event, details, created_at, updated_at, deleted_at)
+SELECT
+    gen_random_uuid(),
+    (al.details->>'user_id')::uuid,
+    assoc.uuid,
+    al.event,
+    al.details,
+    al.created_at,
+    al.updated_at,
+    al.deleted_at
+FROM public.asset_logs_legacy al
+LEFT JOIN public.asset_client_assoc aca ON aca.id = al.assoc_id
+LEFT JOIN public.associations assoc ON
+    assoc.client_id = aca.client_id AND
+    assoc.entry_date = aca.entry_date AND
+    COALESCE(assoc.exit_date, 'infinity') = COALESCE(aca.exit_date, 'infinity') AND
+    assoc.association_type_id = aca.association_id AND
+    ((assoc.equipment_id = aca.asset_id AND assoc.chip_id IS NULL) OR
+     (assoc.chip_id = aca.asset_id AND assoc.equipment_id IS NULL)) AND
+    assoc.deleted_at IS NOT DISTINCT FROM aca.deleted_at
+WHERE al.event LIKE 'ASSOCIATION_%';
+
+-- Migrate remaining asset events
+INSERT INTO public.asset_logs (uuid, user_id, asset_id, event, details, status_before_id, status_after_id, created_at, updated_at, deleted_at)
+SELECT
+    gen_random_uuid(),
+    (details->>'user_id')::uuid,
+    details->>'asset_id',
+    event,
+    details,
+    status_before_id,
+    status_after_id,
+    created_at,
+    updated_at,
+    deleted_at
+FROM public.asset_logs_legacy
+WHERE event NOT LIKE 'ASSOCIATION_%';
+
+DROP TABLE public.asset_logs_legacy;
+DROP SEQUENCE IF EXISTS public.asset_history_id_seq;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- create `association_logs` and UUID-based `asset_logs` tables
- migrate data from legacy `asset_logs`
- fix asset_id type in migrations

## Testing
- `bun run lint`
- `supabase db dump` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d766120148325bea81e6370779d69