### PR TITLE
Add dev association route using new module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import AssetsManagement from "@modules/assets/pages/AssetsManagement";
 import AssetsRanking from "@modules/assets/pages/AssetsRanking";
 import AssetAssociation from "@modules/associations/pages/AssetAssociation";
 import AssociationsList from "@modules/associations/pages/AssociationsList";
+import NewAssociationsPage from "@modules/new-associations/pages/NewAssociationsPage";
 import Clients from "@modules/clients/pages/Clients";
 import RegisterClient from "@modules/clients/pages/RegisterClient";
 import Association from "@modules/associations/pages/Association";
@@ -116,7 +117,7 @@ const App = () => (
                           path="association"
                           element={
                             <AuthRoute requiredRole="suporte">
-                              <AssetAssociation />
+                              <NewAssociationsPage />
                             </AuthRoute>
                           }
                         />

--- a/src/modules/new-associations/pages/NewAssociationsPage.tsx
+++ b/src/modules/new-associations/pages/NewAssociationsPage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { StandardPageHeader } from '@/components/ui/standard-page-header';
+import { Users } from 'lucide-react';
+
+export default function NewAssociationsPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <StandardPageHeader
+        icon={Users}
+        title="Nova Página de Associações"
+        description="Interface em desenvolvimento para associação de ativos"
+      />
+      <p>Conteúdo em desenvolvimento...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple dev associations page
- hook new page into `/dev/asset/association` route

## Testing
- `npm run lint` *(fails: Unexpected any in other files)*

------
https://chatgpt.com/codex/tasks/task_e_687569c093ac83258359274488f36235