### PR TITLE
Implement main chip selection

### DIFF
--- a/src/modules/associations/components/ConfigurationStep.tsx
+++ b/src/modules/associations/components/ConfigurationStep.tsx
@@ -5,7 +5,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Calendar, Settings } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Calendar, Settings, Plus } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 
 interface ConfigurationStepProps {
@@ -15,9 +16,13 @@ interface ConfigurationStepProps {
 
 export const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ state, dispatch }) => {
   const [associationTypes, setAssociationTypes] = useState<any[]>([]);
+  const [solutions, setSolutions] = useState<any[]>([]);
+  const [availableChips, setAvailableChips] = useState<any[]>([]);
 
   useEffect(() => {
     fetchAssociationTypes();
+    fetchSolutions().then(setSolutions);
+    fetchAvailableChips().then(setAvailableChips);
   }, []);
 
   const fetchAssociationTypes = async () => {
@@ -32,6 +37,38 @@ export const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ state, dis
       setAssociationTypes(data || []);
     } catch (error) {
       console.error("Erro ao buscar tipos de associação:", error);
+    }
+  };
+
+  const fetchSolutions = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('solutions')
+        .select('*')
+        .in('name', ['SPEEDY 5g', '4PLUS', '4BLACK'])
+        .eq('deleted_at', null);
+
+      if (error) throw error;
+      return data || [];
+    } catch (error) {
+      console.error('Erro ao buscar soluções:', error);
+      return [];
+    }
+  };
+
+  const fetchAvailableChips = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('chips')
+        .select('*')
+        .eq('deleted_at', null)
+        .eq('status', 'available');
+
+      if (error) throw error;
+      return data || [];
+    } catch (error) {
+      console.error('Erro ao buscar chips disponíveis:', error);
+      return [];
     }
   };
 
@@ -63,7 +100,13 @@ export const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ state, dis
     });
   };
 
+  const handleChipSelect = (assetId: string, chipId: string) => {
+    const currentChip = state.assetConfiguration[assetId]?.chip_id;
+    handleAssetConfig(assetId, 'chip_id', currentChip === chipId ? '' : chipId);
+  };
+
   const equipmentAssets = state.selectedAssets.filter((asset: any) => asset.solution_id !== 11);
+  const assetsWithSpecificSolutions = state.selectedAssets.filter((asset: any) => [1, 4, 2].includes(asset.solution_id));
 
   return (
     <div className="space-y-6">
@@ -159,6 +202,70 @@ export const ConfigurationStep: React.FC<ConfigurationStepProps> = ({ state, dis
                         value={config.password || ''}
                         onChange={(e) => handleAssetConfig(asset.uuid, 'password', e.target.value)}
                       />
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Main Chip Configuration */}
+      {assetsWithSpecificSolutions.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center">
+              <Settings className="mr-2 h-5 w-5" />
+              Configuração de Chip Principal
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {assetsWithSpecificSolutions.map((asset: any) => {
+              const config = state.assetConfiguration[asset.uuid] || {};
+
+              return (
+                <div key={asset.uuid} className="p-4 border rounded-lg space-y-3">
+                  <h4 className="font-medium">
+                    {asset.radio || asset.serial_number || asset.model || 'Equipamento'}
+                  </h4>
+                  <div className="space-y-3">
+                    <Label>Chip Principal</Label>
+                    <div className="space-y-3 max-h-60 overflow-y-auto">
+                      {availableChips.map((chip) => {
+                        const isSelected = config.chip_id === chip.uuid;
+                        return (
+                          <Card
+                            key={chip.uuid}
+                            className={`cursor-pointer transition-colors hover:border-primary ${
+                              isSelected ? 'border-primary bg-primary/5' : ''
+                            }`}
+                            onClick={() => handleChipSelect(asset.uuid, chip.uuid)}
+                          >
+                            <CardContent className="p-3">
+                              <div className="flex items-center justify-between">
+                                <div className="space-y-1">
+                                  <div className="flex items-center gap-2">
+                                    <Badge variant="outline" className="text-xs">
+                                      CHIP
+                                    </Badge>
+                                    {isSelected && <Plus className="h-4 w-4 text-primary" />}
+                                  </div>
+                                  <p className="font-medium">{chip.iccid || 'Sem ICCID'}</p>
+                                  {chip.line_number && (
+                                    <p className="text-sm text-muted-foreground">
+                                      Linha: {chip.line_number}
+                                    </p>
+                                  )}
+                                </div>
+                              </div>
+                            </CardContent>
+                          </Card>
+                        );
+                      })}
+                      {availableChips.length === 0 && (
+                        <p className="text-center text-muted-foreground py-4">Nenhum chip disponível</p>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/modules/associations/hooks/useAssociationFlow.ts
+++ b/src/modules/associations/hooks/useAssociationFlow.ts
@@ -86,10 +86,10 @@ export const useAssociationFlow = () => {
   const createAssociation = useCallback(async () => {
     try {
       // Group assets by type for association creation
-      const equipments = state.selectedAssets.filter(asset => 
+      const equipments = state.selectedAssets.filter(asset =>
         asset.solution_id !== 11 // Not a chip
       );
-      const chips = state.selectedAssets.filter(asset => 
+      const chips = state.selectedAssets.filter(asset =>
         asset.solution_id === 11 // Is a chip
       );
 
@@ -100,8 +100,18 @@ export const useAssociationFlow = () => {
       if (equipments.length > 0 && chips.length > 0) {
         for (const equipment of equipments) {
           // For SPEEDY 5G, 4 PLUS, 4 BLACK - associate with a chip
-          if ([2, 3, 4].includes(equipment.solution_id)) {
-            const chip = chips.shift(); // Take first available chip
+          if ([1, 4, 2].includes(equipment.solution_id)) {
+            const configuredId = state.assetConfiguration[equipment.uuid]?.chip_id;
+            let chip;
+            if (configuredId) {
+              const index = chips.findIndex(c => c.uuid === configuredId);
+              if (index !== -1) {
+                chip = chips.splice(index, 1)[0];
+              }
+            }
+            if (!chip) {
+              chip = chips.shift(); // Take first available chip
+            }
             if (chip) {
               associations.push({
                 client_id: state.client.uuid,

--- a/src/modules/associations/services/associationService.ts
+++ b/src/modules/associations/services/associationService.ts
@@ -2,7 +2,7 @@
 import { supabase } from "@/integrations/supabase/client";
 
 export const associationService = {
-  async create(associationData: any) {
+  async create(associationData: Record<string, unknown>) {
     const { data, error } = await supabase
       .from('associations')
       .insert(associationData)
@@ -50,7 +50,7 @@ export const associationService = {
     return data;
   },
 
-  async update(id: string, updates: any) {
+  async update(id: string, updates: Record<string, unknown>) {
     const { data, error } = await supabase
       .from('associations')
       .update(updates)


### PR DESCRIPTION
## Summary
- add chip fetch helpers and state in ConfigurationStep
- display chip dropdown for 4Plus, 4Black and Speedy assets
- honor chip selection when creating associations
- tighten types in association service
- show available chips as cards like asset selection

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877b88dc8cc8325a2a3fc0ffccd03ee